### PR TITLE
Updates for separation of SimStorage from OPS Storage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,8 @@
+
 [report]
+include =
+    */openpathsampling/experimental/simstore/*
+    */openpathsampling/experimental/storage/*
 omit =
     */test_*py
     */belong_in_pr/*

--- a/examples/01_simple_usage.ipynb
+++ b/examples/01_simple_usage.ipynb
@@ -163,8 +163,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from openpathsampling.experimental.storage.sql_backend import SQLStorageBackend\n",
-    "from openpathsampling.experimental.storage.ops_storage import OPSStorage"
+    "from openpathsampling.experimental.simstore import SQLStorageBackend\n",
+    "from openpathsampling.experimental.storage import Storage"
    ]
   },
   {
@@ -186,7 +186,7 @@
    "outputs": [],
    "source": [
     "backend = SQLStorageBackend(\"storage_01.db\", mode='w')\n",
-    "storage = OPSStorage.from_backend(backend)"
+    "storage = Storage.from_backend(backend)"
    ]
   },
   {

--- a/examples/02_load_old_cvs.ipynb
+++ b/examples/02_load_old_cvs.ipynb
@@ -18,7 +18,7 @@
    "outputs": [],
    "source": [
     "import openpathsampling as paths\n",
-    "from openpathsampling.experimental.storage.monkey_patches import monkey_patch_saving\n",
+    "from openpathsampling.experimental.storage import monkey_patch_saving\n",
     "paths = monkey_patch_saving(paths)"
    ]
   },
@@ -61,8 +61,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from openpathsampling.experimental.storage.sql_backend import SQLStorageBackend\n",
-    "from openpathsampling.experimental.storage.ops_storage import OPSStorage"
+    "from openpathsampling.experimental.simstore import SQLStorageBackend\n",
+    "from openpathsampling.experimental.storage import Storage"
    ]
   },
   {
@@ -72,7 +72,7 @@
    "outputs": [],
    "source": [
     "backend = SQLStorageBackend(\"storage_02.db\", mode='w')\n",
-    "storage = OPSStorage.from_backend(backend)"
+    "storage = Storage.from_backend(backend)"
    ]
   },
   {
@@ -132,7 +132,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from openpathsampling.experimental.storage.monkey_patches import monkey_patch_loading\n",
+    "from openpathsampling.experimental.storage import monkey_patch_loading\n",
     "paths = monkey_patch_loading(paths)\n",
     "\n",
     "# note: If you don't need to load from a netcdfplus file, you can use \n",
@@ -146,7 +146,7 @@
    "outputs": [],
    "source": [
     "backend = SQLStorageBackend(\"storage_02.db\", mode='r')\n",
-    "storage = OPSStorage.from_backend(backend)"
+    "storage = Storage.from_backend(backend)"
    ]
   },
   {

--- a/test-storage.sh
+++ b/test-storage.sh
@@ -2,8 +2,8 @@
 
 ./download-file.sh
 
-py.test --pyargs openpathsampling.experimental.storage \
-        --cov=openpathsampling.experimental.storage
+py.test --pyargs openpathsampling.experimental \
+        --cov=openpathsampling.experimental
 
 py.test --nbval-lax --cov=openpathsampling.experimental.storage --cov-append \
         tests/01_sql_play.ipynb \

--- a/tests/01_sql_play.ipynb
+++ b/tests/01_sql_play.ipynb
@@ -7,8 +7,8 @@
    "outputs": [],
    "source": [
     "from __future__ import print_function\n",
-    "from openpathsampling.experimental.simstore.sql_backend import universal_schema, universal_sql_meta\n",
-    "from openpathsampling.experimental.simstore import SQLStorageBackend\n",
+    "from openpathsampling.experimental.simstore.sql_backend import universal_sql_meta\n",
+    "from openpathsampling.experimental.simstore import SQLStorageBackend, universal_schema\n",
     "st = SQLStorageBackend(\":memory:\", mode='w')\n",
     "import sqlalchemy as sql"
    ]

--- a/tests/01_sql_play.ipynb
+++ b/tests/01_sql_play.ipynb
@@ -2,12 +2,13 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
     "from __future__ import print_function\n",
-    "from openpathsampling.experimental.storage.sql_backend import SQLStorageBackend, universal_schema, universal_sql_meta\n",
+    "from openpathsampling.experimental.simstore.sql_backend import universal_schema, universal_sql_meta\n",
+    "from openpathsampling.experimental.simstore import SQLStorageBackend\n",
     "st = SQLStorageBackend(\":memory:\", mode='w')\n",
     "import sqlalchemy as sql"
    ]

--- a/tests/02_toy_serialization.ipynb
+++ b/tests/02_toy_serialization.ipynb
@@ -120,7 +120,7 @@
     }
    ],
    "source": [
-    "from openpathsampling.experimental.storage.tools import flatten_all\n",
+    "from openpathsampling.experimental.simstore.tools import flatten_all\n",
     "flatten_all(engine.to_dict())"
    ]
   },

--- a/tests/03_toy_storage.ipynb
+++ b/tests/03_toy_storage.ipynb
@@ -12,14 +12,14 @@
     "import openpathsampling.engines.toy as toys\n",
     "import numpy as np\n",
     "\n",
-    "from openpathsampling.experimental.storage.storage import GeneralStorage\n",
-    "from openpathsampling.experimental.storage.class_info import ClassInfoContainer, ClassInfo\n",
-    "from openpathsampling.experimental.storage.storage import universal_schema\n",
-    "from openpathsampling.experimental.storage.sql_backend import SQLStorageBackend\n",
-    "import openpathsampling.experimental.storage.serialization_helpers as serialization\n",
-    "from openpathsampling.experimental.storage import tools\n",
+    "from openpathsampling.experimental.simstore import GeneralStorage\n",
+    "from openpathsampling.experimental.simstore import ClassInfoContainer, ClassInfo\n",
+    "from openpathsampling.experimental.simstore import universal_schema\n",
+    "from openpathsampling.experimental.simstore import SQLStorageBackend\n",
+    "import openpathsampling.experimental.simstore.serialization_helpers as serialization\n",
+    "from openpathsampling.experimental.simstore import tools\n",
     "\n",
-    "from openpathsampling.experimental.storage.my_types import builtin_types"
+    "from openpathsampling.experimental.simstore.my_types import builtin_types"
    ]
   },
   {

--- a/tests/04_registering_snapshots.ipynb
+++ b/tests/04_registering_snapshots.ipynb
@@ -371,7 +371,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from openpathsampling.experimental.storage.ops_storage import Storage, OPSClassInfoContainer"
+    "from openpathsampling.experimental.storage import Storage, OPSClassInfoContainer"
    ]
   },
   {

--- a/tests/04_registering_snapshots.ipynb
+++ b/tests/04_registering_snapshots.ipynb
@@ -155,16 +155,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from openpathsampling.experimental.storage.storage import GeneralStorage\n",
-    "from openpathsampling.experimental.storage.class_info import ClassInfoContainer, ClassInfo\n",
-    "from openpathsampling.experimental.storage.storage import universal_schema\n",
-    "from openpathsampling.experimental.storage.sql_backend import SQLStorageBackend\n",
-    "import openpathsampling.experimental.storage.serialization_helpers as serialization\n",
-    "#from openpathsampling.experimental.storage.serialization import SimulationObjectSerializer\n",
-    "#from openpathsampling.experimental.storage.custom_json import default_serializer_deserializer\n",
-    "from openpathsampling.experimental.storage.custom_json import JSONSerializerDeserializer\n",
-    "from openpathsampling.experimental.storage.custom_json import numpy_codec, bytes_codec, uuid_object_codec\n",
-    "from openpathsampling.experimental.storage import tools\n",
+    "from openpathsampling.experimental.simstore import GeneralStorage\n",
+    "from openpathsampling.experimental.simstore import ClassInfoContainer, ClassInfo\n",
+    "from openpathsampling.experimental.simstore import universal_schema\n",
+    "from openpathsampling.experimental.simstore import SQLStorageBackend\n",
+    "import openpathsampling.experimental.simstore.serialization_helpers as serialization\n",
+    "from openpathsampling.experimental.simstore.custom_json import JSONSerializerDeserializer\n",
+    "from openpathsampling.experimental.simstore.custom_json import numpy_codec, bytes_codec, uuid_object_codec\n",
+    "from openpathsampling.experimental.simstore import tools\n",
     "\n",
     "import openpathsampling.engines.toy as toys\n",
     "\n",
@@ -373,7 +371,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from openpathsampling.experimental.storage.ops_storage import OPSStorage, OPSClassInfoContainer"
+    "from openpathsampling.experimental.storage.ops_storage import Storage, OPSClassInfoContainer"
    ]
   },
   {
@@ -383,7 +381,7 @@
    "outputs": [],
    "source": [
     "backend = SQLStorageBackend(\":memory:\", mode='w')\n",
-    "storage = OPSStorage.from_backend(\n",
+    "storage = Storage.from_backend(\n",
     "    backend=backend,\n",
     "    schema=schema,\n",
     "    class_info=OPSClassInfoContainer(default_info=default_class_info)\n",

--- a/tests/05_toy_snapshot_deserialization.ipynb
+++ b/tests/05_toy_snapshot_deserialization.ipynb
@@ -15,16 +15,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from openpathsampling.experimental.storage.storage import GeneralStorage\n",
-    "from openpathsampling.experimental.storage.class_info import ClassInfoContainer, ClassInfo\n",
-    "from openpathsampling.experimental.storage.storage import universal_schema\n",
-    "from openpathsampling.experimental.storage.sql_backend import SQLStorageBackend\n",
-    "import openpathsampling.experimental.storage.serialization_helpers as serialization\n",
-    "from openpathsampling.experimental.storage import tools\n",
+    "from openpathsampling.experimental.simstore import GeneralStorage\n",
+    "from openpathsampling.experimental.simstore import ClassInfoContainer, ClassInfo\n",
+    "from openpathsampling.experimental.simstore import universal_schema\n",
+    "from openpathsampling.experimental.simstore import SQLStorageBackend\n",
+    "import openpathsampling.experimental.simstore.serialization_helpers as serialization\n",
+    "from openpathsampling.experimental.simstore import tools\n",
     "\n",
     "import openpathsampling.engines.toy as toys\n",
     "\n",
-    "from openpathsampling.experimental.storage.ops_storage import OPSStorage, OPSClassInfoContainer\n",
+    "from openpathsampling.experimental.storage import Storage, OPSClassInfoContainer\n",
     "\n",
     "import numpy as np"
    ]
@@ -82,7 +82,7 @@
    "outputs": [],
    "source": [
     "backend = SQLStorageBackend(\"test.sql\", mode='w')\n",
-    "storage = OPSStorage.from_backend(\n",
+    "storage = Storage.from_backend(\n",
     "    backend=backend,\n",
     "    schema=schema,\n",
     "    class_info=OPSClassInfoContainer(default_info=default_class_info)\n",
@@ -372,7 +372,7 @@
    ],
    "source": [
     "backend = SQLStorageBackend(\"test.sql\", mode='r')\n",
-    "storage = OPSStorage.from_backend(\n",
+    "storage = Storage.from_backend(\n",
     "    backend=backend,\n",
     "    schema=backend.schema,\n",
     "    class_info=OPSClassInfoContainer(default_info=default_class_info)\n",

--- a/tests/06_full_ops_schema.ipynb
+++ b/tests/06_full_ops_schema.ipynb
@@ -7,10 +7,10 @@
    "outputs": [],
    "source": [
     "from __future__ import print_function\n",
-    "from openpathsampling.experimental.storage.ops_storage import OPSStorage, ops_class_info, ops_schema\n",
-    "from openpathsampling.experimental.storage.sql_backend import SQLStorageBackend\n",
+    "from openpathsampling.experimental.storage import Storage, ops_class_info, ops_schema\n",
+    "from openpathsampling.experimental.simstore import SQLStorageBackend\n",
     "import numpy as np\n",
-    "from openpathsampling.experimental.storage.serialization_helpers import get_uuid\n",
+    "from openpathsampling.experimental.simstore.serialization_helpers import get_uuid, get_all_uuids\n",
     "\n",
     "import collections"
    ]
@@ -58,7 +58,7 @@
    ],
    "source": [
     "backend = SQLStorageBackend(\"test.sql\", mode='w')\n",
-    "storage = OPSStorage.from_backend(\n",
+    "storage = Storage.from_backend(\n",
     "    backend=backend,\n",
     "    schema=ops_schema,\n",
     "    class_info=ops_class_info\n",
@@ -104,15 +104,6 @@
    "source": [
     "step_uuid = get_uuid(step)\n",
     "step_uuid"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from openpathsampling.experimental.storage.serialization_helpers import get_all_uuids"
    ]
   },
   {
@@ -1381,7 +1372,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from openpathsampling.experimental.storage.serialization_helpers import default_find_uuids"
+    "from openpathsampling.experimental.simstore.serialization_helpers import default_find_uuids"
    ]
   },
   {

--- a/tests/07_storage_tables.ipynb
+++ b/tests/07_storage_tables.ipynb
@@ -7,10 +7,10 @@
    "outputs": [],
    "source": [
     "from __future__ import print_function\n",
-    "from openpathsampling.experimental.storage.ops_storage import OPSStorage, ops_class_info, ops_schema\n",
-    "from openpathsampling.experimental.storage.sql_backend import SQLStorageBackend\n",
-    "from openpathsampling.experimental.storage.storage import StorageTable\n",
-    "from openpathsampling.experimental.storage.serialization_helpers import get_uuid\n",
+    "from openpathsampling.experimental.storage import Storage, ops_class_info, ops_schema\n",
+    "from openpathsampling.experimental.simstore import SQLStorageBackend\n",
+    "from openpathsampling.experimental.simstore import StorageTable\n",
+    "from openpathsampling.experimental.simstore.serialization_helpers import get_uuid\n",
     "\n",
     "import collections\n",
     "import numpy as np"
@@ -58,7 +58,7 @@
    ],
    "source": [
     "backend = SQLStorageBackend(\"test.sql\", mode='w')\n",
-    "storage = OPSStorage.from_backend(\n",
+    "storage = Storage.from_backend(\n",
     "    backend=backend,\n",
     "    schema=ops_schema,\n",
     "    class_info=ops_class_info\n",
@@ -1288,7 +1288,7 @@
    ],
    "source": [
     "backend = SQLStorageBackend(\"test.sql\", mode='r')\n",
-    "storage = OPSStorage.from_backend(\n",
+    "storage = Storage.from_backend(\n",
     "    backend=backend,\n",
     "    schema=ops_schema,\n",
     "    class_info=ops_class_info\n",


### PR DESCRIPTION
This changes imports to reflect the update that `experimental.simstore` is now separate from `experimental.storage` (latter being OPS-specific things).

Will merge immediately when it passes.