### PR TITLE
Add coverage report (codecov)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,7 @@ script:
   - OPS_GIT=`python -c "import openpathsampling; print(openpathsampling.version.git_hash)"`
   - cd ../openpathsampling && ROOT=`pwd` && cd -
   - ./test-storage.sh
-  - codecov -t $CODECOV_TOKEN --root $ROOT -c $OPS_GIT -b storage \
-            -f unit.xml
-  - codecov -t $CODECOV_TOKEN --root $ROOT -c $OPS_GIT -b storage \
-            -f integration.xml
+  - codecov -t $CODECOV_TOKEN --root $ROOT -c $OPS_GIT -b storage -f unit.xml
+  - codecov -t $CODECOV_TOKEN --root $ROOT -c $OPS_GIT -b storage -f integration.xml
   - ./test-examples.sh
   - cd ../openpathsampling && git checkout origin/storable_functions && cd -

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
 script:
   - cd ../openpathsampling && git checkout origin/storage && cd -
   - ./test-storage.sh
-  - bash <(curl -s https://codecov.io/bash) -f unit.xml
-  - bash <(curl -s https://codecov.io/bash) -f integration.xml 
+  - bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN -f unit.xml
+  - bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN -f integration.xml 
   - ./test-examples.sh
   - cd ../openpathsampling && git checkout origin/storable_functions && cd -

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,16 @@ install:
   - . ${DIR}/conda_ops_dev_install.sh dwhswenson
   - pushd openpathsampling && git fetch && popd
   - popd
+  - pip install codecov
 
 script:
   - cd ../openpathsampling && git checkout origin/storage && cd -
-  - OPS_GIT=`python -c "import openpathsampling;
-                        print(openpathsampling.version.git_hash)"`
+  - OPS_GIT=`python -c "import openpathsampling; print(openpathsampling.version.git_hash)"`
+  - cd ../openpathsampling && ROOT=`pwd` && cd -
   - ./test-storage.sh
-  - bash <(curl -s https://codecov.io/bash) -f unit.xml \
-            -t $CODECOV_TOKEN -N $OPS_GIT -B storage -C $OPS_GIT
-  - bash <(curl -s https://codecov.io/bash) -f integration.xml \
-            -t $CODECOV_TOKEN -N $OPS_GIT -B storage -C $OPS_GIT
-  - ./test-examples.sh
+  - codecov -t $CODECOV_TOKEN --root $ROOT -c $OPS_GIT -b storage \
+            -f unit.xml
+  - codecov -t $CODECOV_TOKEN --root $ROOT -c $OPS_GIT -b storage \
+            -f integration.xml
   - ./test-examples.sh
   - cd ../openpathsampling && git checkout origin/storable_functions && cd -

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,7 @@ install:
 script:
   - cd ../openpathsampling && git checkout origin/storage && cd -
   - ./test-storage.sh
+  - bash <(curl -s https://codecov.io/bash) -f unit.xml -F unit
+  - bash <(curl -s https://codecov.io/bash) -f integration.xml -F integration
   - ./test-examples.sh
   - cd ../openpathsampling && git checkout origin/storable_functions && cd -

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,10 @@ script:
   - OPS_GIT=`python -c "import openpathsampling;
                         print(openpathsampling.version.git_hash)"`
   - ./test-storage.sh
-  - bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN -N $OPS_GIT \
-                                            -f unit.xml
-  - bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN -N $OPS_GIT \
-                                            -f integration.xml 
+  - bash <(curl -s https://codecov.io/bash) -f unit.xml \
+            -t $CODECOV_TOKEN -N $OPS_GIT -B storage -C $OPS_GIT
+  - bash <(curl -s https://codecov.io/bash) -f integration.xml \
+            -t $CODECOV_TOKEN -N $OPS_GIT -B storage -C $OPS_GIT
+  - ./test-examples.sh
   - ./test-examples.sh
   - cd ../openpathsampling && git checkout origin/storable_functions && cd -

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,12 @@ install:
 
 script:
   - cd ../openpathsampling && git checkout origin/storage && cd -
+  - OPS_GIT=`python -c "import openpathsampling;
+                        print(openpathsampling.version.git_hash)"`
   - ./test-storage.sh
-  - bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN -f unit.xml
-  - bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN -f integration.xml 
+  - bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN -N $OPS_GIT \
+                                            -f unit.xml
+  - bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN -N $OPS_GIT \
+                                            -f integration.xml 
   - ./test-examples.sh
   - cd ../openpathsampling && git checkout origin/storable_functions && cd -

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
   - OPS_GIT=`python -c "import openpathsampling; print(openpathsampling.version.git_hash)"`
   - cd ../openpathsampling && ROOT=`pwd` && cd -
   - ./test-storage.sh
-  - codecov -t $CODECOV_TOKEN --root $ROOT -c $OPS_GIT -b storage -f unit.xml
-  - codecov -t $CODECOV_TOKEN --root $ROOT -c $OPS_GIT -b storage -f integration.xml
+  - codecov -t $CODECOV_TOKEN --root $ROOT -c $OPS_GIT -b storage -f unit.xml -F storage-unit
+  - codecov -t $CODECOV_TOKEN --root $ROOT -c $OPS_GIT -b storage -f integration.xml -F storage-integration
   - ./test-examples.sh
   - cd ../openpathsampling && git checkout origin/storable_functions && cd -

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
 script:
   - cd ../openpathsampling && git checkout origin/storage && cd -
   - ./test-storage.sh
-  - bash <(curl -s https://codecov.io/bash) -f unit.xml -F unit
-  - bash <(curl -s https://codecov.io/bash) -f integration.xml -F integration
+  - bash <(curl -s https://codecov.io/bash) -f unit.xml
+  - bash <(curl -s https://codecov.io/bash) -f integration.xml 
   - ./test-examples.sh
   - cd ../openpathsampling && git checkout origin/storable_functions && cd -

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # ops-storage-notebooks
 
+[![Build Status](https://travis-ci.com/dwhswenson/ops-storage-notebooks.svg?branch=master)](https://travis-ci.com/dwhswenson/ops-storage-notebooks)
+[![codecov](https://codecov.io/gh/dwhswenson/openpathsampling/branch/storage/graph/badge.svg)](https://codecov.io/gh/dwhswenson/openpathsampling)
+
 Jupyter notebooks for the new OpenPathSampling storage.
 
 The new OPS storage is slowly adding a full set of unit tests; however, much of

--- a/test-storage.sh
+++ b/test-storage.sh
@@ -3,9 +3,11 @@
 ./download-file.sh
 
 py.test --pyargs openpathsampling.experimental \
-        --cov=openpathsampling.experimental
+        --cov=openpathsampling.experimental \
+        --cov-report=xml:unit.xml
 
-py.test --nbval-lax --cov=openpathsampling.experimental.storage --cov-append \
+py.test --nbval-lax --cov=openpathsampling.experimental \
+        --cov-report=xml:integration.xml \
         tests/01_sql_play.ipynb \
         tests/02_toy_serialization.ipynb \
         tests/03_toy_storage.ipynb \


### PR DESCRIPTION
Adding external coverage support. Using codecov because I think the [flags](https://docs.codecov.io/docs/flags) functionality sound interested. It's especially useful here, where I want to know how much coverage I have including the integration tests, but want to migrate coverage from integration tests to unit tests.