### PR TITLE
Update example; add OpenMM snapshot test notebook

### DIFF
--- a/examples/01_simple_usage.ipynb
+++ b/examples/01_simple_usage.ipynb
@@ -10,7 +10,13 @@
     "\n",
     "We'll load an existing trajectory using a netcdfplus file. Other than that, all objects will be created fresh and in the most OPS-2.0 style currently possible.\n",
     "\n",
-    "NOTE: The main caveat here is that you cannot disk-cache results of an old CV with new storage. However, once new-style CVs are available, you can disk-cache a new CV in new storage."
+    "NOTE: The main caveat here is that you cannot disk-cache results of an old CV with new storage. However, once new-style CVs are available, you can disk-cache a new CV in new storage.\n",
+    "\n",
+    "Big picture of things that you do differently:\n",
+    "\n",
+    "* use new storage, which should have extension `.db` (or `.sql`)\n",
+    "* use new CVs (see below for details on differences in creating new CVs)\n",
+    "* use the monkey-patch methods to adjust some aspects of storage; also let some objects know that we're using SimStore"
    ]
   },
   {
@@ -45,6 +51,35 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Apply monkey-patching\n",
+    "\n",
+    "This should only be done *after* you've loaded any objects from old `.nc` files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openpathsampling.experimental.storage import monkey_patch_all\n",
+    "paths = monkey_patch_all(paths)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# set this before creating the interface sets\n",
+    "paths.InterfaceSet.simstore = True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Create simulation objects\n",
     "\n",
     "This is all taken from the standard OPS MSTIS example."
@@ -52,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,7 +139,6 @@
     "\n",
     "* Name is no longer required; name these the same way as other objects.\n",
     "* kwarg `f` renamed to `func`.\n",
-    "* Currently require that you provide `result_type`: this will change soon, though.\n",
     "* It is no longer necessary to provide a template object to storage before saving a CV.\n",
     "* Everything is disk-cached by default. You can turn that off by setting `cv.mode = 'no-caching'`, but note that this will also turn off memory caching.\n",
     "\n",
@@ -115,7 +149,6 @@
     "    * `func_config`\n",
     "    * `store_source`\n",
     "    \n",
-    "  I hope that `result_type` will be removed from this list soon.\n",
     "* The `store_source` parameter tells whether to store the source for the `func` in the object. By default, it stores the source if it was defined in `__main__` (i.e., if it `func` isn't imported from another package). So, for example, it will not store the source of `md.compute_distances`, but if you write a min-dist function that wraps `md.compute_distances`, it will store the source for that function.\n",
     "* Instead of the old `cv_*` flags, these are each individual `simstore.storable_functions.Processor` objects, which get registered with a `simstore.storable_functions.StorableFunctionConfig` object. You can combine these to get various pre-processing and post-processing effect, and can create new, custom processors (e.g., for MDTraj). The `StorableFunctionConfig` is given to the `func_config` parameter.\n",
     "* There are several \"modes\" that you can use. Set them with `cv.mode = mode`, where mode is one of the strings:\n",
@@ -129,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -159,17 +192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# set this before creating the interface sets\n",
-    "paths.InterfaceSet.simstore = True"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,7 +225,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -211,8 +234,8 @@
      "text": [
       "No missing ensembles.\n",
       "No extra ensembles.\n",
-      "CPU times: user 16.5 s, sys: 1.36 s, total: 17.9 s\n",
-      "Wall time: 18.1 s\n"
+      "CPU times: user 17.5 s, sys: 1.5 s, total: 19 s\n",
+      "Wall time: 20.2 s\n"
      ]
     }
    ],
@@ -232,27 +255,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from openpathsampling.experimental.simstore import SQLStorageBackend\n",
     "from openpathsampling.experimental.storage import Storage"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
-    "backend = SQLStorageBackend(\"storage_01.db\", mode='w')\n",
-    "storage = Storage.from_backend(backend)"
+    "storage = Storage(\"storage_01.db\", mode='w')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -263,7 +284,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nsteps = 200  # testing, won't get overlap for TIS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_SKIP\n",
+    "nsteps = 10000  # when you really run it"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -271,7 +311,7 @@
      "output_type": "stream",
      "text": [
       "Working on Monte Carlo cycle number 10000\n",
-      "Running for 13 minutes 56 seconds -  0.08 seconds per step\n",
+      "Running for 14 minutes 30 seconds -  0.09 seconds per step\n",
       "Estimated time remaining: 0 seconds\n",
       "DONE! Completed 10000 Monte Carlo cycles.\n"
      ]
@@ -279,12 +319,12 @@
    ],
    "source": [
     "simulation.save_frequency = 50  # with toy models, we can hold many steps in memory\n",
-    "simulation.run(200)  # increase to >= 10000 for better analysis"
+    "simulation.run(nsteps)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "metadata": {
     "scrolled": true
    },
@@ -295,17 +335,17 @@
      "text": [
       "File: storage_01.db\n",
       "Includes tables:\n",
-      "* samples: 13110 items\n",
+      "* samples: 13157 items\n",
       "* sample_sets: 10001 items\n",
-      "* trajectories: 8090 items\n",
-      "* move_changes: 47406 items\n",
+      "* trajectories: 8107 items\n",
+      "* move_changes: 47445 items\n",
       "* steps: 10001 items\n",
-      "* details: 46811 items\n",
+      "* details: 46818 items\n",
       "* storable_functions: 6 items\n",
       "* simulation_objects: 393 items\n",
       "* storage_objects: 0 items\n",
-      "* snapshot0: 1511 items\n",
-      "* snapshot1: 320233 items\n",
+      "* snapshot0: 1488 items\n",
+      "* snapshot1: 300376 items\n",
       "\n"
      ]
     }
@@ -323,7 +363,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -341,7 +381,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -352,27 +392,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 482 ms, sys: 24.2 ms, total: 507 ms\n",
-      "Wall time: 592 ms\n"
+      "CPU times: user 413 ms, sys: 19.1 ms, total: 432 ms\n",
+      "Wall time: 452 ms\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
-    "backend = SQLStorageBackend(\"storage_01.db\", mode='r')\n",
-    "storage = Storage.from_backend(backend)"
+    "storage = Storage(\"storage_01.db\", mode='r')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -381,7 +420,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 23,
    "metadata": {
     "scrolled": true
    },
@@ -389,7 +428,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "661611e854794308abab49fa0091c1a1",
+       "model_id": "0602a273894f4ffc88054e695feeb42e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -405,11 +444,11 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "repex ran 22.100% (expected 22.39%) of the cycles with acceptance 416/2210 (18.82%)\n",
-      "shooting ran 45.010% (expected 44.78%) of the cycles with acceptance 3279/4501 (72.85%)\n",
-      "pathreversal ran 24.560% (expected 24.88%) of the cycles with acceptance 2118/2456 (86.24%)\n",
-      "minus ran 2.970% (expected 2.99%) of the cycles with acceptance 283/297 (95.29%)\n",
-      "ms_outer_shooting ran 5.360% (expected 4.98%) of the cycles with acceptance 379/536 (70.71%)\n"
+      "repex ran 22.090% (expected 22.39%) of the cycles with acceptance 384/2209 (17.38%)\n",
+      "shooting ran 44.640% (expected 44.78%) of the cycles with acceptance 3306/4464 (74.06%)\n",
+      "pathreversal ran 25.300% (expected 24.88%) of the cycles with acceptance 2148/2530 (84.90%)\n",
+      "minus ran 3.130% (expected 2.99%) of the cycles with acceptance 303/313 (96.81%)\n",
+      "ms_outer_shooting ran 4.840% (expected 4.98%) of the cycles with acceptance 328/484 (67.77%)\n"
      ]
     }
    ],
@@ -419,7 +458,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,7 +472,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 25,
    "metadata": {
     "scrolled": true
    },
@@ -441,7 +480,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "39a6591b33174160aab398bd82765d18",
+       "model_id": "3e9de2dcfdaf41e699413ecebb7d321d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -460,7 +499,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "HBox(children=(HTML(value=''), FloatProgress(value=0.0, max=79.0), HTML(value='')))"
+       "HBox(children=(HTML(value=''), FloatProgress(value=0.0, max=84.0), HTML(value='')))"
       ]
      },
      "metadata": {},
@@ -474,7 +513,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "HBox(children=(HTML(value=''), FloatProgress(value=0.0, max=103.0), HTML(value='')))"
+       "HBox(children=(HTML(value=''), FloatProgress(value=0.0, max=114.0), HTML(value='')))"
       ]
      },
      "metadata": {},
@@ -488,7 +527,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "HBox(children=(HTML(value=''), FloatProgress(value=0.0, max=101.0), HTML(value='')))"
+       "HBox(children=(HTML(value=''), FloatProgress(value=0.0, max=105.0), HTML(value='')))"
       ]
      },
      "metadata": {},
@@ -504,7 +543,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d397dda7661e4661a492b51fc8b35e52",
+       "model_id": "369a98db7fa4490c90aad3a637fcdd04",
        "version_major": 2,
        "version_minor": 0
       },
@@ -537,7 +576,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "HBox(children=(HTML(value=''), FloatProgress(value=0.0, max=626.0), HTML(value='')))"
+       "HBox(children=(HTML(value=''), FloatProgress(value=0.0, max=656.0), HTML(value='')))"
       ]
      },
      "metadata": {},
@@ -551,7 +590,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "HBox(children=(HTML(value=''), FloatProgress(value=0.0, max=570.0), HTML(value='')))"
+       "HBox(children=(HTML(value=''), FloatProgress(value=0.0, max=594.0), HTML(value='')))"
       ]
      },
      "metadata": {},
@@ -565,63 +604,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "HBox(children=(HTML(value=''), FloatProgress(value=0.0, max=461.0), HTML(value='')))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(HTML(value='Ensembles'), FloatProgress(value=0.0, max=3.0), HTML(value='')))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(HTML(value=''), FloatProgress(value=0.0, max=624.0), HTML(value='')))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(HTML(value=''), FloatProgress(value=0.0, max=609.0), HTML(value='')))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(HTML(value=''), FloatProgress(value=0.0, max=487.0), HTML(value='')))"
+       "HBox(children=(HTML(value=''), FloatProgress(value=0.0, max=454.0), HTML(value='')))"
       ]
      },
      "metadata": {},
@@ -649,7 +632,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "HBox(children=(HTML(value=''), FloatProgress(value=0.0, max=602.0), HTML(value='')))"
+       "HBox(children=(HTML(value=''), FloatProgress(value=0.0, max=662.0), HTML(value='')))"
       ]
      },
      "metadata": {},
@@ -663,7 +646,7 @@
        "version_minor": 0
       },
       "text/plain": [
-       "HBox(children=(HTML(value=''), FloatProgress(value=0.0, max=563.0), HTML(value='')))"
+       "HBox(children=(HTML(value=''), FloatProgress(value=0.0, max=543.0), HTML(value='')))"
       ]
      },
      "metadata": {},
@@ -677,7 +660,63 @@
        "version_minor": 0
       },
       "text/plain": [
-       "HBox(children=(HTML(value=''), FloatProgress(value=0.0, max=535.0), HTML(value='')))"
+       "HBox(children=(HTML(value=''), FloatProgress(value=0.0, max=427.0), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(HTML(value='Ensembles'), FloatProgress(value=0.0, max=3.0), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(HTML(value=''), FloatProgress(value=0.0, max=715.0), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(HTML(value=''), FloatProgress(value=0.0, max=576.0), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(HTML(value=''), FloatProgress(value=0.0, max=508.0), HTML(value='')))"
       ]
      },
      "metadata": {},
@@ -688,8 +727,8 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "CPU times: user 4min 36s, sys: 5.18 s, total: 4min 41s\n",
-      "Wall time: 4min 47s\n"
+      "CPU times: user 4min 25s, sys: 5.1 s, total: 4min 30s\n",
+      "Wall time: 4min 39s\n"
      ]
     }
    ],
@@ -702,7 +741,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -735,19 +774,19 @@
        "    <tr>\n",
        "      <th>B</th>\n",
        "      <td>NaN</td>\n",
-       "      <td>0.00116078</td>\n",
-       "      <td>0.00117099</td>\n",
+       "      <td>0.00242254</td>\n",
+       "      <td>0.00312324</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>C</th>\n",
-       "      <td>0.00141295</td>\n",
+       "      <td>0.00231683</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>0.00149324</td>\n",
+       "      <td>0.00132465</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>A</th>\n",
-       "      <td>0.00361238</td>\n",
-       "      <td>0.00273128</td>\n",
+       "      <td>0.00105299</td>\n",
+       "      <td>0.00101934</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -756,12 +795,12 @@
       ],
       "text/plain": [
        "            B           C           A\n",
-       "B         NaN  0.00116078  0.00117099\n",
-       "C  0.00141295         NaN  0.00149324\n",
-       "A  0.00361238  0.00273128         NaN"
+       "B         NaN  0.00242254  0.00312324\n",
+       "C  0.00231683         NaN  0.00132465\n",
+       "A  0.00105299  0.00101934         NaN"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/test-storage.sh
+++ b/test-storage.sh
@@ -20,6 +20,7 @@ py.test --nbval-lax --cov=openpathsampling.experimental \
         tests/08_reloading.ipynb \
         tests/09_storable_functions.ipynb \
         tests/10_result_typing.ipynb \
+        tests/11_openmm_snapshots.ipynb \
         || failure=1
 
 if [ $failure -eq 1 ]; then

--- a/tests/11_openmm_snapshots.ipynb
+++ b/tests/11_openmm_snapshots.ipynb
@@ -1,0 +1,1284 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import openpathsampling as paths\n",
+    "from openpathsampling.engines import features\n",
+    "\n",
+    "from openpathsampling.experimental.simstore.serialization_helpers import get_uuid\n",
+    "\n",
+    "from openpathsampling.experimental.storage.snapshots import (\n",
+    "    schema_from_entries, schema_for_snapshot, replace_schema_dimensions,\n",
+    "    snapshot_registration_info\n",
+    ")\n",
+    "\n",
+    "import simtk.unit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Parsing types\n",
+    "\n",
+    "### Abstract"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'statics': [('coordinates',\n",
+       "   'simtk(unit.nanometer)*ndarray.float32({n_atoms},{n_spatial})'),\n",
+       "  ('box_vectors',\n",
+       "   'simtk(unit.nanometer)*ndarray.float32({n_spatial},{n_spatial})'),\n",
+       "  ('engine', 'uuid')],\n",
+       " 'kinetics': [('velocities',\n",
+       "   'simtk(unit.nanometer/unit.picosecond)*ndarray.float32({n_atoms},{n_spatial})'),\n",
+       "  ('engine', 'uuid')],\n",
+       " 'snapshot': [('statics', 'lazy'),\n",
+       "  ('kinetics', 'lazy'),\n",
+       "  ('is_reversed', 'bool')]}"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "openmm_schema = schema_from_entries([features.statics, features.kinetics], lazies=['statics', 'kinetics'])\n",
+    "openmm_schema"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'simtk(unit.nanometer/unit.picosecond)*ndarray.float32({n_atoms},{n_spatial})'"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "string = openmm_schema['kinetics'][0][1]\n",
+    "string"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pattern = re.compile(\"simtk\\((.*)\\)\\*((ndarray|float).*)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "match = pattern.match(string)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('unit.nanometer/unit.picosecond', 'ndarray.float32({n_atoms},{n_spatial})')"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "match.group(1), match.group(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "float_string = \"simtk(unit.nanometer/unit.picosecond**2)*float\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'simtk(unit.nanometer/unit.picosecond**2)*float'"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "match = pattern.match(float_string)\n",
+    "match.group(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('unit.nanometer/unit.picosecond**2', 'float')"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "match.group(1), match.group(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### From snapshot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pkg_resources\n",
+    "pdb = pkg_resources.resource_filename('openpathsampling.tests',\n",
+    "                                      'test_data/ala_small_traj.pdb')\n",
+    "snap = paths.engines.openmm.snapshot_from_pdb(pdb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'statics': [('coordinates',\n",
+       "   'simtk(unit.nanometer)*ndarray.float32({n_atoms},{n_spatial})'),\n",
+       "  ('box_vectors',\n",
+       "   'simtk(unit.nanometer)*ndarray.float32({n_spatial},{n_spatial})'),\n",
+       "  ('engine', 'uuid')],\n",
+       " 'kinetics': [('velocities',\n",
+       "   'simtk(unit.nanometer/unit.picosecond)*ndarray.float32({n_atoms},{n_spatial})'),\n",
+       "  ('engine', 'uuid')],\n",
+       " 'snapshot': [('statics', 'lazy'),\n",
+       "  ('kinetics', 'lazy'),\n",
+       "  ('is_reversed', 'bool'),\n",
+       "  ('engine', 'uuid')]}"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "schema_for_snapshot(snap)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "schema, info = snapshot_registration_info(snap, 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert len(info) == 3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ClassInfo(table=snapshot0, cls=<class 'openpathsampling.engines.openmm.snapshot.Snapshot'>, lookup_result=('84082411518742377705054655985724948562', <class 'openpathsampling.engines.openmm.snapshot.Snapshot'>), find_uuids=None)"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "info[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ClassInfo(table=statics0, cls=<class 'openpathsampling.engines.features.shared.StaticContainer'>, lookup_result=('84082411518742377705054655985724948562', <class 'openpathsampling.engines.features.shared.StaticContainer'>), find_uuids=None)"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "info[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ClassInfo(table=kinetics0, cls=<class 'openpathsampling.engines.features.shared.KineticContainer'>, lookup_result=('84082411518742377705054655985724948562', <class 'openpathsampling.engines.features.shared.KineticContainer'>), find_uuids=None)"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "info[2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'statics0': [('coordinates',\n",
+       "   'simtk(unit.nanometer)*ndarray.float32({n_atoms},{n_spatial})'),\n",
+       "  ('box_vectors',\n",
+       "   'simtk(unit.nanometer)*ndarray.float32({n_spatial},{n_spatial})'),\n",
+       "  ('engine', 'uuid')],\n",
+       " 'kinetics0': [('velocities',\n",
+       "   'simtk(unit.nanometer/unit.picosecond)*ndarray.float32({n_atoms},{n_spatial})'),\n",
+       "  ('engine', 'uuid')],\n",
+       " 'snapshot0': [('statics', 'lazy'),\n",
+       "  ('kinetics', 'lazy'),\n",
+       "  ('is_reversed', 'bool'),\n",
+       "  ('engine', 'uuid')]}"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "schema"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using handler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openpathsampling.experimental.storage.simtk_unit import SimtkQuantityHandler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "handler = SimtkQuantityHandler.from_type_string(float_string)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from simtk import unit\n",
+    "q = 1.0 * unit.meter / unit.second**2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "9.999999999999999e-16"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "handler.serialize(q)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Quantity(value=9.999999999999999e-16, unit=nanometer/(picosecond**2))"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "handler.deserialize(handler.serialize(q))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using storage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openpathsampling.experimental.simstore import SQLStorageBackend\n",
+    "from openpathsampling.experimental.storage import Storage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "backend = SQLStorageBackend('test.db', mode='w')\n",
+    "storage = Storage.from_backend(backend)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import sys\n",
+    "\n",
+    "def enable_logging(level=logging.DEBUG):\n",
+    "\n",
+    "    root = logging.getLogger()\n",
+    "    root.setLevel(level)\n",
+    "\n",
+    "    ch = logging.StreamHandler(sys.stdout)\n",
+    "    ch.setLevel(level)\n",
+    "    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')\n",
+    "    ch.setFormatter(formatter)\n",
+    "    root.addHandler(ch)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Checking `is_special`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert storage.class_info.is_special(snap.statics)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert storage.class_info.is_special(snap.kinetics)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Saving"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ensure that we have the handler, whether running before or after that is default\n",
+    "handlers = storage.class_info.attribute_handlers\n",
+    "#storage.class_info.attribute_handlers = list(set(handlers) | {SimtkQuantityHandler})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "storage.save(snap)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openpathsampling.experimental.simstore.serialization.SchemaSerializer at 0x7fb65fa28e80>"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "storage.class_info['statics0'].serializer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'coordinates': <bound method SimtkQuantityHandler.serialize of <openpathsampling.experimental.storage.simtk_unit.SimtkQuantityHandler object at 0x7fb65fa28fd0>>,\n",
+       " 'box_vectors': <bound method SimtkQuantityHandler.serialize of <openpathsampling.experimental.storage.simtk_unit.SimtkQuantityHandler object at 0x7fb65fa284a8>>,\n",
+       " 'engine': <function openpathsampling.experimental.simstore.uuids.get_uuid(obj)>}"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "storage.class_info['statics0'].serializer.attribute_handlers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ser = storage.class_info['statics0'].serializer(snap.statics)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "b'\\x9f\\xcd&@\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x9f\\xcd&@\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x9f\\xcd&@'"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ser['box_vectors']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "existing = {get_uuid(snap.engine): snap.engine}\n",
+    "ser_copy = {k: v for k, v in ser.items()}\n",
+    "deser = storage.class_info['statics0'].deserializer(get_uuid(snap.statics), ser_copy, existing)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Quantity(value=array([[-0.3479,  0.1589,  0.1044],\n",
+       "       [-0.3046,  0.0591,  0.0972],\n",
+       "       [-0.3382,  0.0141,  0.0038],\n",
+       "       ...,\n",
+       "       [-0.93  ,  1.1963,  1.1873],\n",
+       "       [-0.9368,  1.2558,  1.262 ],\n",
+       "       [-0.8732,  1.1257,  1.2181]], dtype=float32), unit=nanometer)"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "deser.coordinates"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "storage.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Loading"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Storage._known_storages = {}\n",
+    "backend = SQLStorageBackend(\"test.db\", mode='r')\n",
+    "storage = Storage.from_backend(backend)\n",
+    "# can't add this after, since type registration happens earlier; must be inte\n",
+    "#storage.class_info.attribute_handlers = list(set(handlers) | {SimtkQuantityHandler})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'samples': openpathsampling.sample.Sample,\n",
+       " 'sample_sets': openpathsampling.sample.SampleSet,\n",
+       " 'trajectories': openpathsampling.engines.trajectory.Trajectory,\n",
+       " 'move_changes': openpathsampling.movechange.MoveChange,\n",
+       " 'steps': openpathsampling.pathsimulators.path_simulator.MCStep,\n",
+       " 'details': openpathsampling.pathmover.Details,\n",
+       " 'storable_functions': openpathsampling.experimental.simstore.storable_functions.StorableFunction,\n",
+       " 'simulation_objects': openpathsampling.netcdfplus.base.StorableObject,\n",
+       " 'storage_objects': openpathsampling.experimental.simstore.storage.GeneralStorage,\n",
+       " 'statics0': openpathsampling.engines.features.shared.StaticContainer,\n",
+       " 'kinetics0': openpathsampling.engines.features.shared.KineticContainer,\n",
+       " 'snapshot0': openpathsampling.engines.openmm.snapshot.Snapshot}"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "backend.table_to_class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[openpathsampling.experimental.simstore.attribute_handlers.NDArrayHandler,\n",
+       " openpathsampling.experimental.simstore.attribute_handlers.StandardHandler,\n",
+       " openpathsampling.experimental.storage.simtk_unit.SimtkQuantityHandler]"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "storage.class_info.attribute_handlers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<openpathsampling.experimental.simstore.serialization.SchemaSerializer at 0x7fb65fa31ac8>"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "storage.class_info['statics0'].serializer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ser_copy = {k: v for k, v in ser.items()}\n",
+    "deser = storage.class_info['statics0'].deserializer(get_uuid(snap.statics), ser_copy, existing)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Quantity(value=array([[2.6063, 0.    , 0.    ],\n",
+       "       [0.    , 2.6063, 0.    ],\n",
+       "       [0.    , 0.    , 2.6063]], dtype=float32), unit=nanometer)"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "deser.box_vectors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'coordinates': <bound method SimtkQuantityHandler.deserialize of <openpathsampling.experimental.storage.simtk_unit.SimtkQuantityHandler object at 0x7fb65e2bf5c0>>,\n",
+       " 'box_vectors': <bound method SimtkQuantityHandler.deserialize of <openpathsampling.experimental.storage.simtk_unit.SimtkQuantityHandler object at 0x7fb65e2bf390>>,\n",
+       " 'engine': <function openpathsampling.experimental.simstore.serialization_helpers.search_caches(key, cache_list, raise_error=True)>}"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "storage.class_info['statics0'].deserializer.attribute_handlers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'uuid': ('uuid', None),\n",
+       " 'lazy': ('lazy', None),\n",
+       " 'list_uuid': ('list_uuid', None),\n",
+       " 'str': ('str', None),\n",
+       " 'json': ('json', None),\n",
+       " 'json_obj': ('json_obj', None),\n",
+       " 'int': ('int', None),\n",
+       " 'float': ('float', None),\n",
+       " 'function': ('function', None),\n",
+       " 'ndarray': ('ndarray', None),\n",
+       " 'bool': ('bool', None),\n",
+       " 'simtk(unit.nanometer)*ndarray.float32(1651,3)': ('ndarray', None),\n",
+       " 'simtk(unit.nanometer)*ndarray.float32(3,3)': ('ndarray', None),\n",
+       " 'simtk(unit.nanometer/unit.picosecond)*ndarray.float32(1651,3)': ('ndarray',\n",
+       "  None)}"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "storage.backend.known_types"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "snap = [s for s in storage.snapshots][0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NOTE: So far we only have proxies for the statics/kinetics!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'__uuid__': 84082411518742377705054655985724948568,\n",
+       " '_lazy': {<openpathsampling.netcdfplus.proxy.DelayedLoader at 0x7fb65d8ed588>: <LazyLoader for StaticContainer UUID 84082411518742377705054655985724948564>,\n",
+       "  <openpathsampling.netcdfplus.proxy.DelayedLoader at 0x7fb65d8ed5c0>: <LazyLoader for KineticContainer UUID 84082411518742377705054655985724948566>},\n",
+       " '_reversed': None,\n",
+       " 'is_reversed': False,\n",
+       " 'engine': <openpathsampling.engines.openmm.tools.FileEngine at 0x7fb65e29c0b8>}"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "vars(snap)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'84082411518742377705054655985724948566'"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# unfortunately, get_uuid seems to trigger loading; want to fix that;\n",
+    "# anything other than repr, uuid, type should trigger getattr; need to play\n",
+    "# with lazies some more\n",
+    "get_uuid(snap.kinetics)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xyz = snap.xyz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Quantity(value=array([[-0.3479,  0.1589,  0.1044],\n",
+       "       [-0.3046,  0.0591,  0.0972],\n",
+       "       [-0.3382,  0.0141,  0.0038],\n",
+       "       ...,\n",
+       "       [-0.93  ,  1.1963,  1.1873],\n",
+       "       [-0.9368,  1.2558,  1.262 ],\n",
+       "       [-0.8732,  1.1257,  1.2181]], dtype=float32), unit=nanometer)"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "snap.coordinates"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert isinstance(snap.box_vectors, simtk.unit.Quantity)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[-0.3479,  0.1589,  0.1044],\n",
+       "       [-0.3046,  0.0591,  0.0972],\n",
+       "       [-0.3382,  0.0141,  0.0038],\n",
+       "       ...,\n",
+       "       [-0.93  ,  1.1963,  1.1873],\n",
+       "       [-0.9368,  1.2558,  1.262 ],\n",
+       "       [-0.8732,  1.1257,  1.2181]], dtype=float32)"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "snap.xyz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "openpathsampling.experimental.simstore.proxy.make_lazy_class.<locals>.LazyLoader"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(snap.kinetics)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ClassInfo(table=statics0, cls=<class 'openpathsampling.engines.features.shared.StaticContainer'>, lookup_result=('84082411518742377705054655985724948562', <class 'openpathsampling.engines.features.shared.StaticContainer'>), find_uuids=<openpathsampling.experimental.simstore.serialization_helpers.SchemaFindUUIDs object at 0x7fb65fa07588>)"
+      ]
+     },
+     "execution_count": 54,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "storage.class_info['statics0']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Re-saving"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Storage._known_storages = {}\n",
+    "backend = SQLStorageBackend(\"test.db\", mode='r')\n",
+    "storage = Storage.from_backend(backend)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Table('kinetics0', MetaData(bind=Engine(sqlite:///test.db)), Column('idx', INTEGER(), table=<kinetics0>, primary_key=True, nullable=False), Column('uuid', VARCHAR(), table=<kinetics0>), Column('velocities', BLOB(), table=<kinetics0>), Column('engine', VARCHAR(), table=<kinetics0>), schema=None)"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "storage.backend.metadata.tables['kinetics0']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "snap = [s for s in storage.snapshots][0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "backend = SQLStorageBackend(\"test2.db\", mode='w')\n",
+    "new_storage = Storage.from_backend(backend)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "enable_logging()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'__uuid__': 84082411518742377705054655985724948568,\n",
+       " '_lazy': {<openpathsampling.netcdfplus.proxy.DelayedLoader at 0x7fb65d8ed588>: <LazyLoader for StaticContainer UUID 84082411518742377705054655985724948564>,\n",
+       "  <openpathsampling.netcdfplus.proxy.DelayedLoader at 0x7fb65d8ed5c0>: <LazyLoader for KineticContainer UUID 84082411518742377705054655985724948566>},\n",
+       " '_reversed': None,\n",
+       " 'is_reversed': False,\n",
+       " 'engine': <openpathsampling.engines.openmm.tools.FileEngine at 0x7fb65e2e0b00>}"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "vars(snap)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2020-12-07 18:25:54,652 - openpathsampling.experimental.simstore.storage - DEBUG - Starting save\n",
+      "2020-12-07 18:25:54,665 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
+      "2020-12-07 18:25:54,669 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
+      "2020-12-07 18:25:54,679 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2020-12-07 18:25:54,680 - openpathsampling.experimental.simstore.storage - DEBUG - Listing all objects to save\n",
+      "2020-12-07 18:25:54,750 - openpathsampling.experimental.simstore.storage - DEBUG - Found 3 objects\n",
+      "2020-12-07 18:25:54,751 - openpathsampling.experimental.simstore.storage - DEBUG - {'84082411518742377705054655985724948568': <openpathsampling.engines.openmm.snapshot.Snapshot object at 0x7fb65e154208>, '84082411518742377705054655985724948562': <openpathsampling.engines.openmm.tools.FileEngine object at 0x7fb65e2e0b00>, '84082411518742377705054655985724948494': <openpathsampling.engines.openmm.topology.MDTrajTopology object at 0x7fb65e0d6208>}\n",
+      "2020-12-07 18:25:54,753 - openpathsampling.experimental.simstore.storage - DEBUG - Deproxying proxy objects\n",
+      "2020-12-07 18:25:54,756 - openpathsampling.experimental.simstore.storage - DEBUG - Found 0 objects to deproxy\n",
+      "2020-12-07 18:25:54,757 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 0 objects\n",
+      "2020-12-07 18:25:54,758 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
+      "2020-12-07 18:25:54,759 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
+      "2020-12-07 18:25:54,760 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2020-12-07 18:25:54,762 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2020-12-07 18:25:54,764 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2020-12-07 18:25:54,767 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2020-12-07 18:25:54,769 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n",
+      "2020-12-07 18:25:54,771 - openpathsampling.experimental.simstore.storage - DEBUG - Checking if objects already exist in database\n",
+      "2020-12-07 18:25:54,772 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 3 UUIDs\n",
+      "2020-12-07 18:25:54,775 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 3 UUIDs\n",
+      "2020-12-07 18:25:54,781 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2020-12-07 18:25:54,783 - openpathsampling.experimental.simstore.storage - DEBUG - Found 0 objects to deproxy\n",
+      "2020-12-07 18:25:54,784 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 0 objects\n",
+      "2020-12-07 18:25:54,786 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
+      "2020-12-07 18:25:54,788 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
+      "2020-12-07 18:25:54,789 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2020-12-07 18:25:54,795 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2020-12-07 18:25:54,797 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2020-12-07 18:25:54,800 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2020-12-07 18:25:54,801 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n",
+      "2020-12-07 18:25:54,802 - openpathsampling.experimental.simstore.storage - INFO - Registering tables for 1 missing objects\n",
+      "2020-12-07 18:25:54,804 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 1 objects\n",
+      "2020-12-07 18:25:54,807 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 1 non-cached objects\n",
+      "2020-12-07 18:25:54,807 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
+      "2020-12-07 18:25:54,808 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
+      "2020-12-07 18:25:54,815 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 1 UUIDs\n",
+      "2020-12-07 18:25:54,818 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 1 objects; creating 0 lazy proxies\n",
+      "2020-12-07 18:25:54,821 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2020-12-07 18:25:54,822 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2020-12-07 18:25:54,824 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2020-12-07 18:25:54,837 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2020-12-07 18:25:54,839 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 2 objects\n",
+      "2020-12-07 18:25:54,840 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 1 objects\n",
+      "2020-12-07 18:25:54,841 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 1 non-cached objects\n",
+      "2020-12-07 18:25:54,843 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
+      "2020-12-07 18:25:54,845 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
+      "2020-12-07 18:25:54,849 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 1 UUIDs\n",
+      "2020-12-07 18:25:54,853 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 1 objects; creating 0 lazy proxies\n",
+      "2020-12-07 18:25:54,854 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2020-12-07 18:25:54,856 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2020-12-07 18:25:54,856 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2020-12-07 18:25:54,860 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2020-12-07 18:25:54,861 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 2 objects\n",
+      "2020-12-07 18:25:54,864 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table statics0\n",
+      "2020-12-07 18:25:54,878 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table kinetics0\n",
+      "2020-12-07 18:25:54,886 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table snapshot0\n",
+      "2020-12-07 18:25:54,911 - openpathsampling.experimental.simstore.storage - INFO - Registered 1 new tables: ['snapshot0']\n",
+      "2020-12-07 18:25:54,912 - openpathsampling.experimental.simstore.storage - DEBUG - Listing all objects to save\n",
+      "2020-12-07 18:25:54,949 - openpathsampling.experimental.simstore.storage - DEBUG - Found 5 objects\n",
+      "2020-12-07 18:25:54,950 - openpathsampling.experimental.simstore.storage - DEBUG - {'84082411518742377705054655985724948568': <openpathsampling.engines.openmm.snapshot.Snapshot object at 0x7fb65e154208>, '84082411518742377705054655985724948564': <openpathsampling.engines.features.shared.StaticContainer object at 0x7fb65f9322e8>, '84082411518742377705054655985724948566': <openpathsampling.engines.features.shared.KineticContainer object at 0x7fb65f9335c0>, '84082411518742377705054655985724948562': <openpathsampling.engines.openmm.tools.FileEngine object at 0x7fb65e2e0b00>, '84082411518742377705054655985724948494': <openpathsampling.engines.openmm.topology.MDTrajTopology object at 0x7fb65e0d6208>}\n",
+      "2020-12-07 18:25:54,951 - openpathsampling.experimental.simstore.storage - DEBUG - Deproxying proxy objects\n",
+      "2020-12-07 18:25:54,953 - openpathsampling.experimental.simstore.storage - DEBUG - Found 0 objects to deproxy\n",
+      "2020-12-07 18:25:54,953 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 0 objects\n",
+      "2020-12-07 18:25:54,956 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
+      "2020-12-07 18:25:54,962 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2020-12-07 18:25:54,964 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2020-12-07 18:25:54,964 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2020-12-07 18:25:54,967 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2020-12-07 18:25:54,971 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2020-12-07 18:25:54,973 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n",
+      "2020-12-07 18:25:54,975 - openpathsampling.experimental.simstore.storage - DEBUG - Checking if objects already exist in database\n",
+      "2020-12-07 18:25:54,979 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 5 UUIDs\n",
+      "2020-12-07 18:25:54,979 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 5 UUIDs\n",
+      "2020-12-07 18:25:54,982 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2020-12-07 18:25:54,994 - openpathsampling.experimental.simstore.storage - DEBUG - Filling 4 tables: ['simulation_objects', 'snapshot0', 'statics0', 'kinetics0']\n",
+      "2020-12-07 18:25:55,001 - openpathsampling.experimental.simstore.storage - DEBUG - Storing 2 objects to table simulation_objects\n",
+      "2020-12-07 18:25:55,052 - openpathsampling.experimental.simstore.storage - DEBUG - Storing complete\n",
+      "2020-12-07 18:25:55,056 - openpathsampling.experimental.simstore.storage - DEBUG - Storing 1 objects to table snapshot0\n",
+      "2020-12-07 18:25:55,067 - openpathsampling.experimental.simstore.storage - DEBUG - Storing complete\n",
+      "2020-12-07 18:25:55,069 - openpathsampling.experimental.simstore.storage - DEBUG - Storing 1 objects to table statics0\n",
+      "2020-12-07 18:25:55,160 - openpathsampling.experimental.simstore.storage - DEBUG - Storing complete\n",
+      "2020-12-07 18:25:55,163 - openpathsampling.experimental.simstore.storage - DEBUG - Storing 1 objects to table kinetics0\n",
+      "2020-12-07 18:25:55,237 - openpathsampling.experimental.simstore.storage - DEBUG - Storing complete\n"
+     ]
+    }
+   ],
+   "source": [
+    "new_storage.save(snap)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'__uuid__': 84082411518742377705054655985724948568,\n",
+       " '_lazy': {<openpathsampling.netcdfplus.proxy.DelayedLoader at 0x7fb65d8ed588>: <openpathsampling.engines.features.shared.StaticContainer object at 0x7fb65f9322e8>,\n",
+       "  <openpathsampling.netcdfplus.proxy.DelayedLoader at 0x7fb65d8ed5c0>: <openpathsampling.engines.features.shared.KineticContainer object at 0x7fb65f9335c0>},\n",
+       " '_reversed': None,\n",
+       " 'is_reversed': False,\n",
+       " 'engine': <openpathsampling.engines.openmm.tools.FileEngine at 0x7fb65e2e0b00>}"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "vars(snap)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": true
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This includes a few (overdue) updates to the main example, including:

* you no longer need to use `from_backend`
* somehow I'd previously left off `monkey_patch_all`

It also adds the notebook for testing support for OpenMM snapshots.