### PR TITLE
Fixes after OPS 985

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ops-storage-notebooks
 
-[![Build Status](https://travis-ci.com/dwhswenson/ops-storage-notebooks.svg?branch=master)](https://travis-ci.com/dwhswenson/ops-storage-notebooks)
+[![Tests](https://github.com/dwhswenson/ops-storage-notebooks/actions/workflows/tests.yml/badge.svg)](https://github.com/dwhswenson/ops-storage-notebooks/actions/workflows/tests.yml)
 [![codecov](https://codecov.io/gh/dwhswenson/openpathsampling/branch/storage/graph/badge.svg)](https://codecov.io/gh/dwhswenson/openpathsampling)
 
 Jupyter notebooks for the new OpenPathSampling storage.

--- a/tests/05_toy_snapshot_deserialization.ipynb
+++ b/tests/05_toy_snapshot_deserialization.ipynb
@@ -21,6 +21,7 @@
     "from openpathsampling.experimental.simstore import SQLStorageBackend\n",
     "import openpathsampling.experimental.simstore.serialization_helpers as serialization\n",
     "from openpathsampling.experimental.simstore import tools\n",
+    "from openpathsampling.experimental.simstore import StorableFunction\n",
     "\n",
     "import openpathsampling.engines.toy as toys\n",
     "\n",
@@ -50,7 +51,11 @@
     "                               cls=StorableObject,\n",
     "                               serializer=serialize_sim,\n",
     "                               deserializer=deserialize_sim,\n",
-    "                               find_uuids=serialization.default_find_uuids)"
+    "                               find_uuids=serialization.default_find_uuids)\n",
+    "storable_functions_info = ClassInfo(table='storable_functions',\n",
+    "                                    cls=StorableFunction,  # this isn't used in this notebook\n",
+    "                                    serializer=serialize_sim,\n",
+    "                                    deserializer=deserialize_sim)"
    ]
   },
   {
@@ -69,7 +74,8 @@
    "outputs": [],
    "source": [
     "schema = {\n",
-    "    'simulation_objects': [('json', 'json_obj'), ('class_idx', 'int')]\n",
+    "    'simulation_objects': [('json', 'json_obj'), ('class_idx', 'int')],\n",
+    "    'storable_functions': [('json', 'json_obj')]\n",
     "}"
    ]
   },
@@ -85,7 +91,8 @@
     "storage = Storage.from_backend(\n",
     "    backend=backend,\n",
     "    schema=schema,\n",
-    "    class_info=OPSClassInfoContainer(default_info=default_class_info)\n",
+    "    class_info=OPSClassInfoContainer(default_info=default_class_info,\n",
+    "                                     class_info_list=[storable_functions_info])\n",
     ")"
    ]
   },
@@ -164,27 +171,63 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-05-19 10:04:50,153 - openpathsampling.experimental.storage.storage - DEBUG - Starting save\n",
-      "2020-05-19 10:04:50,157 - openpathsampling.experimental.storage.sql_backend - DEBUG - Looking for 1 UUIDs\n",
-      "2020-05-19 10:04:50,160 - openpathsampling.experimental.storage.sql_backend - DEBUG - New block of 1 UUIDs\n",
-      "2020-05-19 10:04:50,167 - openpathsampling.experimental.storage.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-05-19 10:04:50,171 - openpathsampling.experimental.storage.storage - DEBUG - Listing all objects to save\n",
-      "2020-05-19 10:04:50,250 - openpathsampling.experimental.storage.storage - DEBUG - Checking if objects already exist in database\n",
-      "2020-05-19 10:04:50,257 - openpathsampling.experimental.storage.sql_backend - DEBUG - Looking for 11 UUIDs\n",
-      "2020-05-19 10:04:50,258 - openpathsampling.experimental.storage.sql_backend - DEBUG - New block of 11 UUIDs\n",
-      "2020-05-19 10:04:50,261 - openpathsampling.experimental.storage.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-05-19 10:04:50,263 - openpathsampling.experimental.storage.storage - INFO - Registering tables for 1 missing objects\n",
-      "2020-05-19 10:04:50,265 - openpathsampling.experimental.storage.sql_backend - INFO - Add schema table snapshot0\n",
-      "2020-05-19 10:04:50,275 - openpathsampling.experimental.storage.storage - INFO - Registered 1 new tables: ['snapshot0']\n",
-      "2020-05-19 10:04:50,277 - openpathsampling.experimental.storage.storage - DEBUG - Filling 2 tables: ['simulation_objects', 'snapshot0']\n",
-      "2020-05-19 10:04:50,278 - openpathsampling.experimental.storage.storage - DEBUG - Storing 10 objects to table simulation_objects\n",
-      "2020-05-19 10:04:50,304 - openpathsampling.experimental.storage.storage - DEBUG - Storing complete\n",
-      "2020-05-19 10:04:50,313 - openpathsampling.experimental.storage.storage - DEBUG - Storing 1 objects to table snapshot0\n",
-      "2020-05-19 10:04:50,330 - openpathsampling.experimental.storage.storage - DEBUG - Storing complete\n",
-      "2020-05-19 10:04:50,331 - openpathsampling.experimental.storage.storage - DEBUG - Starting save\n",
-      "2020-05-19 10:04:50,332 - openpathsampling.experimental.storage.sql_backend - DEBUG - Looking for 1 UUIDs\n",
-      "2020-05-19 10:04:50,335 - openpathsampling.experimental.storage.sql_backend - DEBUG - New block of 1 UUIDs\n",
-      "2020-05-19 10:04:50,338 - openpathsampling.experimental.storage.sql_backend - DEBUG - Found 1 UUIDs\n"
+      "2021-03-10 09:25:43,769 - openpathsampling.experimental.simstore.storage - DEBUG - Starting save\n",
+      "2021-03-10 09:25:43,776 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
+      "2021-03-10 09:25:43,780 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
+      "2021-03-10 09:25:43,800 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-03-10 09:25:43,807 - openpathsampling.experimental.simstore.storage - DEBUG - Listing all objects to save\n",
+      "2021-03-10 09:25:43,826 - openpathsampling.experimental.simstore.storage - DEBUG - Found 11 objects\n",
+      "2021-03-10 09:25:43,839 - openpathsampling.experimental.simstore.storage - DEBUG - Deproxying proxy objects\n",
+      "2021-03-10 09:25:43,841 - openpathsampling.experimental.simstore.storage - DEBUG - Found 0 objects to deproxy\n",
+      "2021-03-10 09:25:43,847 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 0 objects\n",
+      "2021-03-10 09:25:43,864 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
+      "2021-03-10 09:25:43,876 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
+      "2021-03-10 09:25:43,879 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2021-03-10 09:25:43,881 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2021-03-10 09:25:43,883 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2021-03-10 09:25:43,905 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-03-10 09:25:43,906 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n",
+      "2021-03-10 09:25:43,907 - openpathsampling.experimental.simstore.storage - DEBUG - Checking if objects already exist in database\n",
+      "2021-03-10 09:25:43,908 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 11 UUIDs\n",
+      "2021-03-10 09:25:43,910 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 11 UUIDs\n",
+      "2021-03-10 09:25:43,913 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-03-10 09:25:43,914 - openpathsampling.experimental.simstore.storage - DEBUG - Found 0 objects to deproxy\n",
+      "2021-03-10 09:25:43,914 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 0 objects\n",
+      "2021-03-10 09:25:43,915 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
+      "2021-03-10 09:25:43,916 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
+      "2021-03-10 09:25:43,917 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2021-03-10 09:25:43,918 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2021-03-10 09:25:43,919 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2021-03-10 09:25:43,947 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-03-10 09:25:43,948 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n",
+      "2021-03-10 09:25:43,949 - openpathsampling.experimental.simstore.storage - INFO - Registering tables for 1 missing objects\n",
+      "2021-03-10 09:25:43,950 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table snapshot0\n",
+      "2021-03-10 09:25:43,982 - openpathsampling.experimental.simstore.storage - INFO - Registered 1 new tables: ['snapshot0']\n",
+      "2021-03-10 09:25:43,984 - openpathsampling.experimental.simstore.storage - DEBUG - Listing all objects to save\n",
+      "2021-03-10 09:25:43,987 - openpathsampling.experimental.simstore.storage - DEBUG - Found 11 objects\n",
+      "2021-03-10 09:25:43,988 - openpathsampling.experimental.simstore.storage - DEBUG - Deproxying proxy objects\n",
+      "2021-03-10 09:25:43,989 - openpathsampling.experimental.simstore.storage - DEBUG - Found 0 objects to deproxy\n",
+      "2021-03-10 09:25:43,991 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 0 objects\n",
+      "2021-03-10 09:25:43,994 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
+      "2021-03-10 09:25:43,995 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
+      "2021-03-10 09:25:43,998 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2021-03-10 09:25:44,001 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2021-03-10 09:25:44,003 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2021-03-10 09:25:44,010 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-03-10 09:25:44,011 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n",
+      "2021-03-10 09:25:44,014 - openpathsampling.experimental.simstore.storage - DEBUG - Checking if objects already exist in database\n",
+      "2021-03-10 09:25:44,016 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 11 UUIDs\n",
+      "2021-03-10 09:25:44,018 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 11 UUIDs\n",
+      "2021-03-10 09:25:44,023 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-03-10 09:25:44,024 - openpathsampling.experimental.simstore.storage - DEBUG - Filling 2 tables: ['simulation_objects', 'snapshot0']\n",
+      "2021-03-10 09:25:44,026 - openpathsampling.experimental.simstore.storage - DEBUG - Storing 10 objects to table simulation_objects\n",
+      "2021-03-10 09:25:44,040 - openpathsampling.experimental.simstore.storage - DEBUG - Storing complete\n",
+      "2021-03-10 09:25:44,042 - openpathsampling.experimental.simstore.storage - DEBUG - Storing 1 objects to table snapshot0\n",
+      "2021-03-10 09:25:44,061 - openpathsampling.experimental.simstore.storage - DEBUG - Storing complete\n",
+      "2021-03-10 09:25:44,063 - openpathsampling.experimental.simstore.storage - DEBUG - Starting save\n",
+      "2021-03-10 09:25:44,065 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
+      "2021-03-10 09:25:44,067 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
+      "2021-03-10 09:25:44,074 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 1 UUIDs\n"
      ]
     }
    ],
@@ -212,7 +255,14 @@
     {
      "data": {
       "text/plain": [
-       "['schema', 'metadata', 'uuid', 'tables', 'simulation_objects', 'snapshot0']"
+       "['schema',\n",
+       " 'metadata',\n",
+       " 'uuid',\n",
+       " 'tables',\n",
+       " 'tags',\n",
+       " 'simulation_objects',\n",
+       " 'storable_functions',\n",
+       " 'snapshot0']"
       ]
      },
      "execution_count": 12,
@@ -258,115 +308,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-05-19 10:04:50,428 - openpathsampling.experimental.storage.storage - INFO - Missing info from 1 dynamically-registered tables\n",
-      "2020-05-19 10:04:50,429 - openpathsampling.experimental.storage.ops_storage - INFO - Attempting to register missing table snapshot0 (<class 'openpathsampling.engines.toy.snapshot.ToySnapshot'>)\n",
-      "2020-05-19 10:04:50,438 - openpathsampling.experimental.storage.ops_storage - INFO - Found 1 possible lookups\n",
-      "2020-05-19 10:04:50,439 - openpathsampling.experimental.storage.ops_storage - INFO - Lookups for tables: dict_keys(['snapshot0'])\n",
-      "2020-05-19 10:04:50,441 - openpathsampling.experimental.storage.storage - INFO - Successfully registered 1 missing tables\n",
-      "2020-05-19 10:04:50,445 - openpathsampling.experimental.storage.storage - DEBUG - Starting to load 1 objects\n",
-      "2020-05-19 10:04:50,448 - openpathsampling.experimental.storage.storage - DEBUG - Getting internal structure of 1 non-cached objects\n",
-      "2020-05-19 10:04:50,449 - openpathsampling.experimental.storage.sql_backend - DEBUG - Looking for 1 UUIDs\n",
-      "2020-05-19 10:04:50,450 - openpathsampling.experimental.storage.sql_backend - DEBUG - New block of 1 UUIDs\n",
-      "2020-05-19 10:04:50,456 - openpathsampling.experimental.storage.sql_backend - DEBUG - Found 1 UUIDs\n",
-      "2020-05-19 10:04:50,462 - openpathsampling.experimental.storage.sql_backend - DEBUG - Looking for 2 UUIDs\n",
-      "2020-05-19 10:04:50,463 - openpathsampling.experimental.storage.sql_backend - DEBUG - New block of 2 UUIDs\n",
-      "2020-05-19 10:04:50,466 - openpathsampling.experimental.storage.sql_backend - DEBUG - Found 2 UUIDs\n",
-      "2020-05-19 10:04:50,475 - openpathsampling.experimental.storage.sql_backend - DEBUG - Looking for 1 UUIDs\n",
-      "2020-05-19 10:04:50,477 - openpathsampling.experimental.storage.sql_backend - DEBUG - New block of 1 UUIDs\n",
-      "2020-05-19 10:04:50,482 - openpathsampling.experimental.storage.sql_backend - DEBUG - Found 1 UUIDs\n",
-      "2020-05-19 10:04:50,487 - openpathsampling.experimental.storage.sql_backend - DEBUG - Looking for 2 UUIDs\n",
-      "2020-05-19 10:04:50,488 - openpathsampling.experimental.storage.sql_backend - DEBUG - New block of 2 UUIDs\n",
-      "2020-05-19 10:04:50,490 - openpathsampling.experimental.storage.sql_backend - DEBUG - Found 2 UUIDs\n",
-      "2020-05-19 10:04:50,493 - openpathsampling.experimental.storage.sql_backend - DEBUG - Looking for 2 UUIDs\n",
-      "2020-05-19 10:04:50,494 - openpathsampling.experimental.storage.sql_backend - DEBUG - New block of 2 UUIDs\n",
-      "2020-05-19 10:04:50,496 - openpathsampling.experimental.storage.sql_backend - DEBUG - Found 2 UUIDs\n",
-      "2020-05-19 10:04:50,499 - openpathsampling.experimental.storage.sql_backend - DEBUG - Looking for 2 UUIDs\n",
-      "2020-05-19 10:04:50,501 - openpathsampling.experimental.storage.sql_backend - DEBUG - New block of 2 UUIDs\n",
-      "2020-05-19 10:04:50,504 - openpathsampling.experimental.storage.sql_backend - DEBUG - Found 2 UUIDs\n",
-      "2020-05-19 10:04:50,507 - openpathsampling.experimental.storage.storage - DEBUG - Loading 10 objects; creating 0 lazy proxies\n",
-      "2020-05-19 10:04:50,509 - openpathsampling.experimental.storage.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
-      "2020-05-19 10:04:50,512 - openpathsampling.experimental.storage.sql_backend - DEBUG - Looking for 0 UUIDs\n",
-      "2020-05-19 10:04:50,513 - openpathsampling.experimental.storage.sql_backend - DEBUG - New block of 0 UUIDs\n",
-      "2020-05-19 10:04:50,515 - openpathsampling.experimental.storage.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-05-19 10:04:50,517 - openpathsampling.experimental.storage.storage - DEBUG - Reconstructing from 10 objects\n",
-      "2020-05-19 10:04:50,520 - openpathsampling.experimental.storage.storage - DEBUG - Starting to load 1 objects\n",
-      "2020-05-19 10:04:50,525 - openpathsampling.experimental.storage.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
-      "2020-05-19 10:04:50,526 - openpathsampling.experimental.storage.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
-      "2020-05-19 10:04:50,527 - openpathsampling.experimental.storage.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
-      "2020-05-19 10:04:50,528 - openpathsampling.experimental.storage.sql_backend - DEBUG - Looking for 0 UUIDs\n",
-      "2020-05-19 10:04:50,530 - openpathsampling.experimental.storage.sql_backend - DEBUG - New block of 0 UUIDs\n",
-      "2020-05-19 10:04:50,535 - openpathsampling.experimental.storage.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-05-19 10:04:50,536 - openpathsampling.experimental.storage.storage - DEBUG - Reconstructing from 0 objects\n",
-      "2020-05-19 10:04:50,538 - openpathsampling.experimental.storage.storage - DEBUG - Starting to load 1 objects\n",
-      "2020-05-19 10:04:50,541 - openpathsampling.experimental.storage.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
-      "2020-05-19 10:04:50,543 - openpathsampling.experimental.storage.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
-      "2020-05-19 10:04:50,555 - openpathsampling.experimental.storage.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
-      "2020-05-19 10:04:50,556 - openpathsampling.experimental.storage.sql_backend - DEBUG - Looking for 0 UUIDs\n",
-      "2020-05-19 10:04:50,557 - openpathsampling.experimental.storage.sql_backend - DEBUG - New block of 0 UUIDs\n",
-      "2020-05-19 10:04:50,559 - openpathsampling.experimental.storage.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-05-19 10:04:50,560 - openpathsampling.experimental.storage.storage - DEBUG - Reconstructing from 0 objects\n",
-      "2020-05-19 10:04:50,563 - openpathsampling.experimental.storage.storage - DEBUG - Starting to load 1 objects\n",
-      "2020-05-19 10:04:50,566 - openpathsampling.experimental.storage.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
-      "2020-05-19 10:04:50,567 - openpathsampling.experimental.storage.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
-      "2020-05-19 10:04:50,569 - openpathsampling.experimental.storage.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
-      "2020-05-19 10:04:50,570 - openpathsampling.experimental.storage.sql_backend - DEBUG - Looking for 0 UUIDs\n",
-      "2020-05-19 10:04:50,570 - openpathsampling.experimental.storage.sql_backend - DEBUG - New block of 0 UUIDs\n",
-      "2020-05-19 10:04:50,583 - openpathsampling.experimental.storage.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-05-19 10:04:50,584 - openpathsampling.experimental.storage.storage - DEBUG - Reconstructing from 0 objects\n",
-      "2020-05-19 10:04:50,585 - openpathsampling.experimental.storage.storage - DEBUG - Starting to load 1 objects\n",
-      "2020-05-19 10:04:50,586 - openpathsampling.experimental.storage.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
-      "2020-05-19 10:04:50,587 - openpathsampling.experimental.storage.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
-      "2020-05-19 10:04:50,588 - openpathsampling.experimental.storage.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
-      "2020-05-19 10:04:50,589 - openpathsampling.experimental.storage.sql_backend - DEBUG - Looking for 0 UUIDs\n",
-      "2020-05-19 10:04:50,589 - openpathsampling.experimental.storage.sql_backend - DEBUG - New block of 0 UUIDs\n",
-      "2020-05-19 10:04:50,593 - openpathsampling.experimental.storage.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-05-19 10:04:50,594 - openpathsampling.experimental.storage.storage - DEBUG - Reconstructing from 0 objects\n",
-      "2020-05-19 10:04:50,595 - openpathsampling.experimental.storage.storage - DEBUG - Starting to load 1 objects\n",
-      "2020-05-19 10:04:50,597 - openpathsampling.experimental.storage.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
-      "2020-05-19 10:04:50,598 - openpathsampling.experimental.storage.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
-      "2020-05-19 10:04:50,600 - openpathsampling.experimental.storage.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
-      "2020-05-19 10:04:50,601 - openpathsampling.experimental.storage.sql_backend - DEBUG - Looking for 0 UUIDs\n",
-      "2020-05-19 10:04:50,602 - openpathsampling.experimental.storage.sql_backend - DEBUG - New block of 0 UUIDs\n",
-      "2020-05-19 10:04:50,607 - openpathsampling.experimental.storage.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-05-19 10:04:50,608 - openpathsampling.experimental.storage.storage - DEBUG - Reconstructing from 0 objects\n",
-      "2020-05-19 10:04:50,609 - openpathsampling.experimental.storage.storage - DEBUG - Starting to load 1 objects\n",
-      "2020-05-19 10:04:50,610 - openpathsampling.experimental.storage.storage - DEBUG - Getting internal structure of 0 non-cached objects\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2020-05-19 10:04:50,612 - openpathsampling.experimental.storage.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
-      "2020-05-19 10:04:50,613 - openpathsampling.experimental.storage.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
-      "2020-05-19 10:04:50,614 - openpathsampling.experimental.storage.sql_backend - DEBUG - Looking for 0 UUIDs\n",
-      "2020-05-19 10:04:50,615 - openpathsampling.experimental.storage.sql_backend - DEBUG - New block of 0 UUIDs\n",
-      "2020-05-19 10:04:50,618 - openpathsampling.experimental.storage.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-05-19 10:04:50,619 - openpathsampling.experimental.storage.storage - DEBUG - Reconstructing from 0 objects\n",
-      "2020-05-19 10:04:50,620 - openpathsampling.experimental.storage.storage - DEBUG - Starting to load 1 objects\n",
-      "2020-05-19 10:04:50,621 - openpathsampling.experimental.storage.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
-      "2020-05-19 10:04:50,622 - openpathsampling.experimental.storage.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
-      "2020-05-19 10:04:50,623 - openpathsampling.experimental.storage.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
-      "2020-05-19 10:04:50,626 - openpathsampling.experimental.storage.sql_backend - DEBUG - Looking for 0 UUIDs\n",
-      "2020-05-19 10:04:50,628 - openpathsampling.experimental.storage.sql_backend - DEBUG - New block of 0 UUIDs\n",
-      "2020-05-19 10:04:50,632 - openpathsampling.experimental.storage.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-05-19 10:04:50,633 - openpathsampling.experimental.storage.storage - DEBUG - Reconstructing from 0 objects\n",
-      "2020-05-19 10:04:50,634 - openpathsampling.experimental.storage.storage - DEBUG - Starting to load 1 objects\n",
-      "2020-05-19 10:04:50,634 - openpathsampling.experimental.storage.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
-      "2020-05-19 10:04:50,635 - openpathsampling.experimental.storage.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
-      "2020-05-19 10:04:50,636 - openpathsampling.experimental.storage.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
-      "2020-05-19 10:04:50,637 - openpathsampling.experimental.storage.sql_backend - DEBUG - Looking for 0 UUIDs\n",
-      "2020-05-19 10:04:50,638 - openpathsampling.experimental.storage.sql_backend - DEBUG - New block of 0 UUIDs\n",
-      "2020-05-19 10:04:50,640 - openpathsampling.experimental.storage.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-05-19 10:04:50,641 - openpathsampling.experimental.storage.storage - DEBUG - Reconstructing from 0 objects\n",
-      "2020-05-19 10:04:50,642 - openpathsampling.experimental.storage.storage - DEBUG - Starting to load 1 objects\n",
-      "2020-05-19 10:04:50,643 - openpathsampling.experimental.storage.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
-      "2020-05-19 10:04:50,643 - openpathsampling.experimental.storage.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
-      "2020-05-19 10:04:50,644 - openpathsampling.experimental.storage.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
-      "2020-05-19 10:04:50,645 - openpathsampling.experimental.storage.sql_backend - DEBUG - Looking for 0 UUIDs\n",
-      "2020-05-19 10:04:50,646 - openpathsampling.experimental.storage.sql_backend - DEBUG - New block of 0 UUIDs\n",
-      "2020-05-19 10:04:50,649 - openpathsampling.experimental.storage.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-05-19 10:04:50,650 - openpathsampling.experimental.storage.storage - DEBUG - Reconstructing from 0 objects\n"
+      "2021-03-10 09:25:44,193 - openpathsampling.experimental.simstore.storage - INFO - Missing info from 1 dynamically-registered tables\n",
+      "2021-03-10 09:25:44,194 - openpathsampling.experimental.storage.ops_storage - INFO - Attempting to register missing table snapshot0 (<class 'openpathsampling.engines.toy.snapshot.ToySnapshot'>)\n",
+      "2021-03-10 09:25:44,203 - openpathsampling.experimental.storage.ops_storage - INFO - Found 1 possible lookups\n",
+      "2021-03-10 09:25:44,204 - openpathsampling.experimental.storage.ops_storage - INFO - Lookups for tables: dict_keys(['snapshot0'])\n",
+      "2021-03-10 09:25:44,207 - openpathsampling.experimental.simstore.storage - INFO - Successfully registered 1 missing tables\n",
+      "2021-03-10 09:25:44,214 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 10 objects\n",
+      "2021-03-10 09:25:44,216 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 10 non-cached objects\n",
+      "2021-03-10 09:25:44,219 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 10 UUIDs\n",
+      "2021-03-10 09:25:44,223 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 10 UUIDs\n",
+      "2021-03-10 09:25:44,240 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 10 UUIDs\n",
+      "2021-03-10 09:25:44,244 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 10 objects; creating 0 lazy proxies\n",
+      "2021-03-10 09:25:44,246 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2021-03-10 09:25:44,246 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2021-03-10 09:25:44,247 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2021-03-10 09:25:44,254 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-03-10 09:25:44,259 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 10 objects\n",
+      "2021-03-10 09:25:44,276 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 10 objects\n",
+      "2021-03-10 09:25:44,278 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
+      "2021-03-10 09:25:44,281 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
+      "2021-03-10 09:25:44,285 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2021-03-10 09:25:44,288 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2021-03-10 09:25:44,292 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2021-03-10 09:25:44,299 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-03-10 09:25:44,301 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n"
      ]
     }
    ],
@@ -375,7 +340,8 @@
     "storage = Storage.from_backend(\n",
     "    backend=backend,\n",
     "    schema=backend.schema,\n",
-    "    class_info=OPSClassInfoContainer(default_info=default_class_info)\n",
+    "    class_info=OPSClassInfoContainer(default_info=default_class_info,\n",
+    "                                     class_info_list=[storable_functions_info])\n",
     ")"
    ]
   },
@@ -398,7 +364,7 @@
     {
      "data": {
       "text/plain": [
-       "{0: 'simulation_objects', 1: 'snapshot0'}"
+       "{0: 'simulation_objects', 1: 'storable_functions', 2: 'snapshot0'}"
       ]
      },
      "execution_count": 16,
@@ -418,7 +384,7 @@
     {
      "data": {
       "text/plain": [
-       "ClassInfo(table=simulation_objects, cls=<class 'openpathsampling.netcdfplus.base.StorableObject'>, lookup_result=<class 'openpathsampling.netcdfplus.base.StorableObject'>, find_uuids=None)"
+       "ClassInfo(table=simulation_objects, cls=<class 'openpathsampling.netcdfplus.base.StorableObject'>, lookup_result=<class 'openpathsampling.netcdfplus.base.StorableObject'>, find_uuids=<function default_find_uuids at 0x7f9768c38f28>)"
       ]
      },
      "execution_count": 17,
@@ -439,20 +405,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-05-19 10:04:50,681 - openpathsampling.experimental.storage.storage - DEBUG - Starting to load 1 objects\n",
-      "2020-05-19 10:04:50,684 - openpathsampling.experimental.storage.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
-      "2020-05-19 10:04:50,685 - openpathsampling.experimental.storage.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
-      "2020-05-19 10:04:50,686 - openpathsampling.experimental.storage.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
-      "2020-05-19 10:04:50,687 - openpathsampling.experimental.storage.sql_backend - DEBUG - Looking for 0 UUIDs\n",
-      "2020-05-19 10:04:50,688 - openpathsampling.experimental.storage.sql_backend - DEBUG - New block of 0 UUIDs\n",
-      "2020-05-19 10:04:50,690 - openpathsampling.experimental.storage.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-05-19 10:04:50,692 - openpathsampling.experimental.storage.storage - DEBUG - Reconstructing from 0 objects\n"
+      "2021-03-10 09:25:44,359 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 1 objects\n",
+      "2021-03-10 09:25:44,361 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
+      "2021-03-10 09:25:44,362 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
+      "2021-03-10 09:25:44,364 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2021-03-10 09:25:44,365 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2021-03-10 09:25:44,366 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2021-03-10 09:25:44,382 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-03-10 09:25:44,385 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "[<openpathsampling.engines.toy.engine.ToyEngine at 0x1137dfc88>]"
+       "[<openpathsampling.engines.toy.engine.ToyEngine at 0x7f976921e278>]"
       ]
      },
      "execution_count": 18,
@@ -473,14 +439,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-05-19 10:04:50,702 - openpathsampling.experimental.storage.storage - DEBUG - Starting to load 1 objects\n",
-      "2020-05-19 10:04:50,704 - openpathsampling.experimental.storage.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
-      "2020-05-19 10:04:50,705 - openpathsampling.experimental.storage.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
-      "2020-05-19 10:04:50,707 - openpathsampling.experimental.storage.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
-      "2020-05-19 10:04:50,709 - openpathsampling.experimental.storage.sql_backend - DEBUG - Looking for 0 UUIDs\n",
-      "2020-05-19 10:04:50,711 - openpathsampling.experimental.storage.sql_backend - DEBUG - New block of 0 UUIDs\n",
-      "2020-05-19 10:04:50,723 - openpathsampling.experimental.storage.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-05-19 10:04:50,725 - openpathsampling.experimental.storage.storage - DEBUG - Reconstructing from 0 objects\n"
+      "2021-03-10 09:25:44,400 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 1 objects\n",
+      "2021-03-10 09:25:44,403 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
+      "2021-03-10 09:25:44,404 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
+      "2021-03-10 09:25:44,405 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2021-03-10 09:25:44,407 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2021-03-10 09:25:44,408 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2021-03-10 09:25:44,411 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-03-10 09:25:44,412 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n"
      ]
     }
    ],
@@ -504,9 +470,9 @@
        "  'retries_when_max_length': 0,\n",
        "  'on_retry': 'full',\n",
        "  'on_error': 'fail',\n",
-       "  'integ': <openpathsampling.engines.toy.integrators.LangevinBAOABIntegrator at 0x1137dfa20>,\n",
+       "  'integ': <openpathsampling.engines.toy.integrators.LangevinBAOABIntegrator at 0x7f9769208f28>,\n",
        "  'n_steps_per_frame': 1},\n",
-       " 'topology': <openpathsampling.engines.toy.topology.ToyTopology at 0x1137dfb38>}"
+       " 'topology': <openpathsampling.engines.toy.topology.ToyTopology at 0x7f976921e160>}"
       ]
      },
      "execution_count": 20,
@@ -529,23 +495,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-05-19 10:04:50,740 - openpathsampling.experimental.storage.storage - DEBUG - Starting to load 1 objects\n",
-      "2020-05-19 10:04:50,743 - openpathsampling.experimental.storage.storage - DEBUG - Getting internal structure of 1 non-cached objects\n",
-      "2020-05-19 10:04:50,749 - openpathsampling.experimental.storage.sql_backend - DEBUG - Looking for 1 UUIDs\n",
-      "2020-05-19 10:04:50,750 - openpathsampling.experimental.storage.sql_backend - DEBUG - New block of 1 UUIDs\n",
-      "2020-05-19 10:04:50,753 - openpathsampling.experimental.storage.sql_backend - DEBUG - Found 1 UUIDs\n",
-      "2020-05-19 10:04:50,756 - openpathsampling.experimental.storage.storage - DEBUG - Loading 1 objects; creating 0 lazy proxies\n",
-      "2020-05-19 10:04:50,758 - openpathsampling.experimental.storage.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
-      "2020-05-19 10:04:50,760 - openpathsampling.experimental.storage.sql_backend - DEBUG - Looking for 0 UUIDs\n",
-      "2020-05-19 10:04:50,762 - openpathsampling.experimental.storage.sql_backend - DEBUG - New block of 0 UUIDs\n",
-      "2020-05-19 10:04:50,765 - openpathsampling.experimental.storage.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-05-19 10:04:50,766 - openpathsampling.experimental.storage.storage - DEBUG - Reconstructing from 2 objects\n"
+      "2021-03-10 09:25:44,439 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 1 objects\n",
+      "2021-03-10 09:25:44,441 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 1 non-cached objects\n",
+      "2021-03-10 09:25:44,443 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
+      "2021-03-10 09:25:44,445 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
+      "2021-03-10 09:25:44,448 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 1 UUIDs\n",
+      "2021-03-10 09:25:44,464 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 1 objects; creating 0 lazy proxies\n",
+      "2021-03-10 09:25:44,465 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2021-03-10 09:25:44,467 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2021-03-10 09:25:44,468 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2021-03-10 09:25:44,474 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-03-10 09:25:44,475 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 2 objects\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "[<openpathsampling.engines.toy.snapshot.ToySnapshot at 0x1137db160>]"
+       "[<openpathsampling.engines.toy.snapshot.ToySnapshot at 0x7f976921e780>]"
       ]
      },
      "execution_count": 21,
@@ -566,14 +532,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-05-19 10:04:50,780 - openpathsampling.experimental.storage.storage - DEBUG - Starting to load 1 objects\n",
-      "2020-05-19 10:04:50,782 - openpathsampling.experimental.storage.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
-      "2020-05-19 10:04:50,783 - openpathsampling.experimental.storage.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
-      "2020-05-19 10:04:50,784 - openpathsampling.experimental.storage.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
-      "2020-05-19 10:04:50,785 - openpathsampling.experimental.storage.sql_backend - DEBUG - Looking for 0 UUIDs\n",
-      "2020-05-19 10:04:50,786 - openpathsampling.experimental.storage.sql_backend - DEBUG - New block of 0 UUIDs\n",
-      "2020-05-19 10:04:50,788 - openpathsampling.experimental.storage.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-05-19 10:04:50,789 - openpathsampling.experimental.storage.storage - DEBUG - Reconstructing from 0 objects\n"
+      "2021-03-10 09:25:44,494 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 1 objects\n",
+      "2021-03-10 09:25:44,495 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
+      "2021-03-10 09:25:44,498 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
+      "2021-03-10 09:25:44,499 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2021-03-10 09:25:44,502 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2021-03-10 09:25:44,505 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2021-03-10 09:25:44,519 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-03-10 09:25:44,521 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n"
      ]
     }
    ],
@@ -591,7 +557,7 @@
     {
      "data": {
       "text/plain": [
-       "139948483702057181973983775567520989208"
+       "69444820112187497213593907980687900710"
       ]
      },
      "execution_count": 23,
@@ -611,7 +577,7 @@
     {
      "data": {
       "text/plain": [
-       "'139948483702057181973983775567520989208'"
+       "'69444820112187497213593907980687900710'"
       ]
      },
      "execution_count": 24,
@@ -631,7 +597,7 @@
     {
      "data": {
       "text/plain": [
-       "139948483702057181973983775567520989206"
+       "69444820112187497213593907980687900708"
       ]
      },
      "execution_count": 25,
@@ -680,7 +646,7 @@
     {
      "data": {
       "text/plain": [
-       "[(1, '139948483702057181973983775567520989208', b'\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00', b'\\x00\\x00\\x00\\xbf\\x00\\x00\\x00\\xbf', '139948483702057181973983775567520989206')]"
+       "[(1, '69444820112187497213593907980687900710', b'\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00', b'\\x00\\x00\\x00\\xbf\\x00\\x00\\x00\\xbf', '69444820112187497213593907980687900708')]"
       ]
      },
      "execution_count": 28,
@@ -702,7 +668,7 @@
     {
      "data": {
       "text/plain": [
-       "(1, '139948483702057181973983775567520989208', b'\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00', b'\\x00\\x00\\x00\\xbf\\x00\\x00\\x00\\xbf', '139948483702057181973983775567520989206')"
+       "(1, '69444820112187497213593907980687900710', b'\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00', b'\\x00\\x00\\x00\\xbf\\x00\\x00\\x00\\xbf', '69444820112187497213593907980687900708')"
       ]
      },
      "execution_count": 29,
@@ -722,7 +688,7 @@
     {
      "data": {
       "text/plain": [
-       "ClassInfo(table=snapshot0, cls=<class 'openpathsampling.engines.toy.snapshot.ToySnapshot'>, lookup_result=('139948483702057181973983775567520989206', <class 'openpathsampling.engines.toy.snapshot.ToySnapshot'>), find_uuids=<openpathsampling.experimental.storage.serialization_helpers.SchemaFindUUIDs object at 0x1137bbef0>)"
+       "ClassInfo(table=snapshot0, cls=<class 'openpathsampling.engines.toy.snapshot.ToySnapshot'>, lookup_result=('69444820112187497213593907980687900708', <class 'openpathsampling.engines.toy.snapshot.ToySnapshot'>), find_uuids=<openpathsampling.experimental.simstore.serialization_helpers.SchemaFindUUIDs object at 0x7f97692022b0>)"
       ]
      },
      "execution_count": 30,
@@ -742,7 +708,7 @@
     {
      "data": {
       "text/plain": [
-       "ClassInfo(table=simulation_objects, cls=<class 'openpathsampling.netcdfplus.base.StorableObject'>, lookup_result=<class 'openpathsampling.netcdfplus.base.StorableObject'>, find_uuids=None)"
+       "ClassInfo(table=simulation_objects, cls=<class 'openpathsampling.netcdfplus.base.StorableObject'>, lookup_result=<class 'openpathsampling.netcdfplus.base.StorableObject'>, find_uuids=<function default_find_uuids at 0x7f9768c38f28>)"
       ]
      },
      "execution_count": 31,
@@ -764,7 +730,7 @@
     {
      "data": {
       "text/plain": [
-       "SerializationSchema(default_info=ClassInfo(table=simulation_objects, cls=<class 'openpathsampling.netcdfplus.base.StorableObject'>, lookup_result=<class 'openpathsampling.netcdfplus.base.StorableObject'>, find_uuids=None), class_info_list=[ClassInfo(table=simulation_objects, cls=<class 'openpathsampling.netcdfplus.base.StorableObject'>, lookup_result=<class 'openpathsampling.netcdfplus.base.StorableObject'>, find_uuids=None), ClassInfo(table=snapshot0, cls=<class 'openpathsampling.engines.toy.snapshot.ToySnapshot'>, lookup_result=('139948483702057181973983775567520989206', <class 'openpathsampling.engines.toy.snapshot.ToySnapshot'>), find_uuids=<openpathsampling.experimental.storage.serialization_helpers.SchemaFindUUIDs object at 0x1137bbef0>)])"
+       "SerializationSchema(default_info=ClassInfo(table=simulation_objects, cls=<class 'openpathsampling.netcdfplus.base.StorableObject'>, lookup_result=<class 'openpathsampling.netcdfplus.base.StorableObject'>, find_uuids=<function default_find_uuids at 0x7f9768c38f28>), class_info_list=[ClassInfo(table=simulation_objects, cls=<class 'openpathsampling.netcdfplus.base.StorableObject'>, lookup_result=<class 'openpathsampling.netcdfplus.base.StorableObject'>, find_uuids=<function default_find_uuids at 0x7f9768c38f28>), ClassInfo(table=simulation_objects, cls=<class 'openpathsampling.netcdfplus.base.StorableObject'>, lookup_result=<class 'openpathsampling.netcdfplus.base.StorableObject'>, find_uuids=<function default_find_uuids at 0x7f9768c38f28>), ClassInfo(table=storable_functions, cls=<class 'openpathsampling.experimental.simstore.storable_functions.StorableFunction'>, lookup_result=<class 'openpathsampling.experimental.simstore.storable_functions.StorableFunction'>, find_uuids=<openpathsampling.experimental.simstore.serialization_helpers.SchemaFindUUIDs object at 0x7f97690f7fd0>), ClassInfo(table=snapshot0, cls=<class 'openpathsampling.engines.toy.snapshot.ToySnapshot'>, lookup_result=('69444820112187497213593907980687900708', <class 'openpathsampling.engines.toy.snapshot.ToySnapshot'>), find_uuids=<openpathsampling.experimental.simstore.serialization_helpers.SchemaFindUUIDs object at 0x7f97692022b0>)])"
       ]
      },
      "execution_count": 32,
@@ -789,18 +755,6 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.3"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Tests here have been failing since openpathsampling/openpathsampling#985 got merged in, because now SimStore storages *must* have a table called `storable_functions`. One of the development notebooks, notebook 5, didn't use the standard list of OPS tables and therefore didn't include that one (since it came before storable functions were developed).

This PR also fixes the README badge for tests to point to GH actions.