### PR TITLE
Fix: Backend must define serialization for SFRs

### DIFF
--- a/tests/09_storable_functions.ipynb
+++ b/tests/09_storable_functions.ipynb
@@ -87,10 +87,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:37,083 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e8fcaac8>>\n",
-      "2020-11-09 14:12:37,085 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_storage of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e8fcaac8>>\n",
-      "2020-11-09 14:12:37,088 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._eval of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e8fcaac8>>\n",
-      "CPU times: user 6.21 ms, sys: 2.81 ms, total: 9.02 ms\n",
+      "2021-07-22 12:05:33,445 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df3c0750>>\n",
+      "2021-07-22 12:05:33,452 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_storage of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df3c0750>>\n",
+      "2021-07-22 12:05:33,454 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._eval of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df3c0750>>\n",
+      "CPU times: user 5.06 ms, sys: 2.39 ms, total: 7.45 ms\n",
       "Wall time: 2.01 s\n"
      ]
     },
@@ -119,9 +119,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:39,120 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e8fcaac8>>\n",
-      "CPU times: user 1.18 ms, sys: 906 µs, total: 2.08 ms\n",
-      "Wall time: 1.51 ms\n"
+      "2021-07-22 12:05:35,477 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df3c0750>>\n",
+      "CPU times: user 1.29 ms, sys: 1.37 ms, total: 2.66 ms\n",
+      "Wall time: 6.12 ms\n"
      ]
     },
     {
@@ -158,25 +158,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:39,157 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table uuid\n",
-      "2020-11-09 14:12:39,158 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table tables\n",
-      "2020-11-09 14:12:39,169 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table samples\n",
-      "2020-11-09 14:12:39,178 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table sample_sets\n",
-      "2020-11-09 14:12:39,183 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table trajectories\n",
-      "2020-11-09 14:12:39,190 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table move_changes\n",
-      "2020-11-09 14:12:39,201 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table steps\n",
-      "2020-11-09 14:12:39,208 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table details\n",
-      "2020-11-09 14:12:39,215 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table storable_functions\n",
-      "2020-11-09 14:12:39,224 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table simulation_objects\n",
-      "2020-11-09 14:12:39,230 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table storage_objects\n",
-      "2020-11-09 14:12:39,267 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 0 objects\n",
-      "2020-11-09 14:12:39,268 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
-      "2020-11-09 14:12:39,269 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
-      "2020-11-09 14:12:39,270 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
-      "2020-11-09 14:12:39,271 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
-      "2020-11-09 14:12:39,272 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
-      "2020-11-09 14:12:39,285 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-11-09 14:12:39,286 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n"
+      "2021-07-22 12:05:35,533 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table uuid\n",
+      "2021-07-22 12:05:35,535 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table tables\n",
+      "2021-07-22 12:05:35,537 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table sfr_result_types\n",
+      "2021-07-22 12:05:35,540 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table tags\n",
+      "2021-07-22 12:05:35,579 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table samples\n",
+      "2021-07-22 12:05:35,593 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table sample_sets\n",
+      "2021-07-22 12:05:35,608 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table trajectories\n",
+      "2021-07-22 12:05:35,619 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table move_changes\n",
+      "2021-07-22 12:05:35,631 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table steps\n",
+      "2021-07-22 12:05:35,665 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table details\n",
+      "2021-07-22 12:05:35,687 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table storable_functions\n",
+      "2021-07-22 12:05:35,708 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table simulation_objects\n",
+      "2021-07-22 12:05:35,718 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table storage_objects\n",
+      "2021-07-22 12:05:35,771 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 0 objects\n",
+      "2021-07-22 12:05:35,773 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
+      "2021-07-22 12:05:35,774 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
+      "2021-07-22 12:05:35,776 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2021-07-22 12:05:35,777 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2021-07-22 12:05:35,778 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2021-07-22 12:05:35,790 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:35,792 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n"
      ]
     }
    ],
@@ -207,13 +209,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:39,307 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e8fcaac8>>\n"
+      "2021-07-22 12:05:35,855 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df3c0750>>\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'80100521955429081778427985284781047824': 3.0}"
+       "{'218455970078904451893013535049010642960': 3.0}"
       ]
      },
      "execution_count": 10,
@@ -235,11 +237,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:39,320 - openpathsampling.experimental.simstore.sql_backend - INFO - Registering storable function: UUID: 80100521955429081778427985284781047820 (float)\n"
+      "2021-07-22 12:05:35,881 - openpathsampling.experimental.simstore.sql_backend - INFO - Registering storable function: UUID: 218455970078904451893013535049010642956 (float)\n"
      ]
     }
    ],
    "source": [
+    "from openpathsampling.experimental.simstore.attribute_handlers import StandardHandler\n",
+    "backend.serialization['float'] = StandardHandler('float')\n",
+    "\n",
     "backend.register_storable_function(table_name=uuid, result_type='float')"
    ]
   },
@@ -252,7 +257,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:39,412 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n"
+      "2021-07-22 12:05:35,908 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n"
      ]
     }
    ],
@@ -270,13 +275,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:39,433 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 1 UUIDs\n"
+      "2021-07-22 12:05:35,936 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 1 UUIDs\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'80100521955429081778427985284781047824': 3.0}"
+       "{'218455970078904451893013535049010642960': 3.0}"
       ]
      },
      "execution_count": 13,
@@ -296,7 +301,7 @@
     {
      "data": {
       "text/plain": [
-       "{'80100521955429081778427985284781047824': 3.0}"
+       "{'218455970078904451893013535049010642960': 3.0}"
       ]
      },
      "execution_count": 14,
@@ -326,25 +331,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:39,467 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table uuid\n",
-      "2020-11-09 14:12:39,469 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table tables\n",
-      "2020-11-09 14:12:39,490 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table samples\n",
-      "2020-11-09 14:12:39,504 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table sample_sets\n",
-      "2020-11-09 14:12:39,534 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table trajectories\n",
-      "2020-11-09 14:12:39,571 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table move_changes\n",
-      "2020-11-09 14:12:39,585 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table steps\n",
-      "2020-11-09 14:12:39,596 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table details\n",
-      "2020-11-09 14:12:39,607 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table storable_functions\n",
-      "2020-11-09 14:12:39,619 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table simulation_objects\n",
-      "2020-11-09 14:12:39,628 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table storage_objects\n",
-      "2020-11-09 14:12:39,671 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 0 objects\n",
-      "2020-11-09 14:12:39,673 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
-      "2020-11-09 14:12:39,674 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
-      "2020-11-09 14:12:39,676 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
-      "2020-11-09 14:12:39,679 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
-      "2020-11-09 14:12:39,681 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
-      "2020-11-09 14:12:39,688 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-11-09 14:12:39,694 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n"
+      "2021-07-22 12:05:35,976 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table uuid\n",
+      "2021-07-22 12:05:35,978 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table tables\n",
+      "2021-07-22 12:05:35,982 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table sfr_result_types\n",
+      "2021-07-22 12:05:35,991 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table tags\n",
+      "2021-07-22 12:05:36,017 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table samples\n",
+      "2021-07-22 12:05:36,045 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table sample_sets\n",
+      "2021-07-22 12:05:36,061 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table trajectories\n",
+      "2021-07-22 12:05:36,072 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table move_changes\n",
+      "2021-07-22 12:05:36,089 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table steps\n",
+      "2021-07-22 12:05:36,097 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table details\n",
+      "2021-07-22 12:05:36,109 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table storable_functions\n",
+      "2021-07-22 12:05:36,117 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table simulation_objects\n",
+      "2021-07-22 12:05:36,130 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table storage_objects\n",
+      "2021-07-22 12:05:36,181 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 0 objects\n",
+      "2021-07-22 12:05:36,182 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
+      "2021-07-22 12:05:36,186 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
+      "2021-07-22 12:05:36,187 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2021-07-22 12:05:36,188 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2021-07-22 12:05:36,190 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2021-07-22 12:05:36,196 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:36,198 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n"
      ]
     }
    ],
@@ -388,23 +395,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:39,774 - openpathsampling.experimental.simstore.storage - DEBUG - Starting save\n",
-      "2020-11-09 14:12:39,781 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
-      "2020-11-09 14:12:39,783 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
-      "2020-11-09 14:12:39,790 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-11-09 14:12:39,792 - openpathsampling.experimental.simstore.storage - DEBUG - Listing all objects to save\n",
-      "2020-11-09 14:12:39,801 - openpathsampling.experimental.simstore.storage - DEBUG - Checking if objects already exist in database\n",
-      "2020-11-09 14:12:39,803 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 2 UUIDs\n",
-      "2020-11-09 14:12:39,809 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 2 UUIDs\n",
-      "2020-11-09 14:12:39,816 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-11-09 14:12:39,819 - openpathsampling.experimental.simstore.storage - INFO - Saving results from 1 storable functions\n",
-      "2020-11-09 14:12:39,824 - openpathsampling.experimental.simstore.storable_functions - INFO - Result type unknown; unable to create table\n",
-      "2020-11-09 14:12:39,826 - openpathsampling.experimental.simstore.storable_functions - DEBUG - Registering new function: 80100521955429081778427985284781047820\n",
-      "2020-11-09 14:12:39,828 - openpathsampling.experimental.simstore.sql_backend - INFO - Registering storable function: UUID: 80100521955429081778427985284781047820 (float)\n",
-      "2020-11-09 14:12:39,855 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-11-09 14:12:39,860 - openpathsampling.experimental.simstore.storage - DEBUG - Filling 1 tables: ['storable_functions']\n",
-      "2020-11-09 14:12:39,863 - openpathsampling.experimental.simstore.storage - DEBUG - Storing 1 objects to table storable_functions\n",
-      "2020-11-09 14:12:39,875 - openpathsampling.experimental.simstore.storage - DEBUG - Storing complete\n"
+      "2021-07-22 12:05:36,250 - openpathsampling.experimental.simstore.storage - DEBUG - Starting save\n",
+      "2021-07-22 12:05:36,257 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
+      "2021-07-22 12:05:36,260 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
+      "2021-07-22 12:05:36,266 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:36,268 - openpathsampling.experimental.simstore.storage - DEBUG - Listing all objects to save\n",
+      "2021-07-22 12:05:36,271 - openpathsampling.experimental.simstore.storage - DEBUG - Found 2 objects\n",
+      "2021-07-22 12:05:36,273 - openpathsampling.experimental.simstore.storage - DEBUG - Deproxying proxy objects\n",
+      "2021-07-22 12:05:36,275 - openpathsampling.experimental.simstore.storage - DEBUG - Found 0 objects to deproxy\n",
+      "2021-07-22 12:05:36,277 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 0 objects\n",
+      "2021-07-22 12:05:36,279 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
+      "2021-07-22 12:05:36,283 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
+      "2021-07-22 12:05:36,285 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2021-07-22 12:05:36,289 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2021-07-22 12:05:36,290 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2021-07-22 12:05:36,296 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:36,298 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n",
+      "2021-07-22 12:05:36,301 - openpathsampling.experimental.simstore.storage - DEBUG - Checking if objects already exist in database\n",
+      "2021-07-22 12:05:36,303 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 2 UUIDs\n",
+      "2021-07-22 12:05:36,304 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 2 UUIDs\n",
+      "2021-07-22 12:05:36,309 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:36,313 - openpathsampling.experimental.simstore.storage - INFO - Saving results from 1 storable functions\n",
+      "2021-07-22 12:05:36,315 - openpathsampling.experimental.simstore.storable_functions - INFO - Result type unknown; unable to create table\n",
+      "2021-07-22 12:05:36,318 - openpathsampling.experimental.simstore.storable_functions - DEBUG - Registering new function: 218455970078904451893013535049010642956\n",
+      "2021-07-22 12:05:36,321 - openpathsampling.experimental.simstore.storable_functions - DEBUG - Result type: float\n",
+      "2021-07-22 12:05:36,322 - openpathsampling.experimental.simstore.sql_backend - INFO - Registering storable function: UUID: 218455970078904451893013535049010642956 (float)\n",
+      "2021-07-22 12:05:36,366 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:36,373 - openpathsampling.experimental.simstore.storage - DEBUG - Filling 1 tables: ['storable_functions']\n",
+      "2021-07-22 12:05:36,375 - openpathsampling.experimental.simstore.storage - DEBUG - Storing 1 objects to table storable_functions\n",
+      "2021-07-22 12:05:36,389 - openpathsampling.experimental.simstore.storage - DEBUG - Storing complete\n"
      ]
     }
    ],
@@ -440,7 +459,7 @@
     {
      "data": {
       "text/plain": [
-       "dict_keys(['schema', 'metadata', 'uuid', 'tables', 'samples', 'sample_sets', 'trajectories', 'move_changes', 'steps', 'details', 'storable_functions', 'simulation_objects', 'storage_objects', '80100521955429081778427985284781047820'])"
+       "dict_keys(['schema', 'metadata', 'uuid', 'tables', 'sfr_result_types', 'tags', 'samples', 'sample_sets', 'trajectories', 'move_changes', 'steps', 'details', 'storable_functions', 'simulation_objects', 'storage_objects', '218455970078904451893013535049010642956'])"
       ]
      },
      "execution_count": 19,
@@ -460,7 +479,7 @@
     {
      "data": {
       "text/plain": [
-       "{'80100521955429081778427985284781047824': 3.0}"
+       "{'218455970078904451893013535049010642960': 3.0}"
       ]
      },
      "execution_count": 20,
@@ -481,13 +500,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:39,953 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 1 UUIDs\n"
+      "2021-07-22 12:05:36,477 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 1 UUIDs\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'80100521955429081778427985284781047824': 3.0}"
+       "{'218455970078904451893013535049010642960': 3.0}"
       ]
      },
      "execution_count": 21,
@@ -517,18 +536,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:40,172 - openpathsampling.experimental.simstore.storage - INFO - Missing info from 0 dynamically-registered tables\n",
-      "2020-11-09 14:12:40,174 - openpathsampling.experimental.storage.ops_storage - INFO - Found 0 possible lookups\n",
-      "2020-11-09 14:12:40,176 - openpathsampling.experimental.storage.ops_storage - INFO - Lookups for tables: dict_keys([])\n",
-      "2020-11-09 14:12:40,178 - openpathsampling.experimental.simstore.storage - INFO - Successfully registered 0 missing tables\n",
-      "2020-11-09 14:12:40,192 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 0 objects\n",
-      "2020-11-09 14:12:40,193 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
-      "2020-11-09 14:12:40,199 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
-      "2020-11-09 14:12:40,201 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
-      "2020-11-09 14:12:40,204 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
-      "2020-11-09 14:12:40,206 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
-      "2020-11-09 14:12:40,210 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-11-09 14:12:40,214 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n"
+      "2021-07-22 12:05:36,614 - openpathsampling.experimental.simstore.storage - INFO - Missing info from 0 dynamically-registered tables\n",
+      "2021-07-22 12:05:36,615 - openpathsampling.experimental.storage.ops_storage - INFO - Found 0 possible lookups\n",
+      "2021-07-22 12:05:36,616 - openpathsampling.experimental.storage.ops_storage - INFO - Lookups for tables: dict_keys([])\n",
+      "2021-07-22 12:05:36,629 - openpathsampling.experimental.simstore.storage - INFO - Successfully registered 0 missing tables\n",
+      "2021-07-22 12:05:36,646 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 1 objects\n",
+      "2021-07-22 12:05:36,647 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 1 non-cached objects\n",
+      "2021-07-22 12:05:36,648 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
+      "2021-07-22 12:05:36,651 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
+      "2021-07-22 12:05:36,655 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 1 UUIDs\n",
+      "2021-07-22 12:05:36,658 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 1 objects; creating 0 lazy proxies\n",
+      "2021-07-22 12:05:36,659 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2021-07-22 12:05:36,660 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2021-07-22 12:05:36,663 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2021-07-22 12:05:36,680 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:36,688 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 1 objects\n",
+      "2021-07-22 12:05:36,692 - openpathsampling.experimental.simstore.storable_functions - DEBUG - Registering new function: 218455970078904451893013535049010642956\n",
+      "2021-07-22 12:05:36,700 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 1 objects\n",
+      "2021-07-22 12:05:36,702 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
+      "2021-07-22 12:05:36,704 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
+      "2021-07-22 12:05:36,706 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2021-07-22 12:05:36,708 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2021-07-22 12:05:36,711 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2021-07-22 12:05:36,716 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:36,722 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n"
      ]
     }
    ],
@@ -550,19 +581,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:40,236 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 1 objects\n",
-      "2020-11-09 14:12:40,239 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 1 non-cached objects\n",
-      "2020-11-09 14:12:40,241 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
-      "2020-11-09 14:12:40,246 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
-      "2020-11-09 14:12:40,253 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 1 UUIDs\n",
-      "2020-11-09 14:12:40,257 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 1 objects; creating 0 lazy proxies\n",
-      "2020-11-09 14:12:40,260 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
-      "2020-11-09 14:12:40,262 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
-      "2020-11-09 14:12:40,265 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
-      "2020-11-09 14:12:40,272 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-11-09 14:12:40,274 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 1 objects\n",
-      "2020-11-09 14:12:40,278 - openpathsampling.netcdfplus.base - DEBUG - Nameable object is renamed from `[StorableFunction]` to `[StorableFunction]`\n",
-      "2020-11-09 14:12:40,279 - openpathsampling.experimental.simstore.storable_functions - DEBUG - Registering new function: 80100521955429081778427985284781047820\n"
+      "2021-07-22 12:05:36,743 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 1 objects\n",
+      "2021-07-22 12:05:36,745 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
+      "2021-07-22 12:05:36,748 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
+      "2021-07-22 12:05:36,750 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2021-07-22 12:05:36,752 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2021-07-22 12:05:36,754 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2021-07-22 12:05:36,767 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:36,768 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n"
      ]
     }
    ],
@@ -619,11 +645,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:40,331 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e91255c0>>\n",
-      "2020-11-09 14:12:40,334 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_storage of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e91255c0>>\n",
-      "2020-11-09 14:12:40,341 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 1 UUIDs\n",
-      "CPU times: user 6.26 ms, sys: 2.57 ms, total: 8.84 ms\n",
-      "Wall time: 11.2 ms\n"
+      "2021-07-22 12:05:36,806 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df56c810>>\n",
+      "2021-07-22 12:05:36,809 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_storage of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df56c810>>\n",
+      "2021-07-22 12:05:36,821 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 1 UUIDs\n",
+      "CPU times: user 8.08 ms, sys: 2.91 ms, total: 11 ms\n",
+      "Wall time: 15.8 ms\n"
      ]
     },
     {
@@ -673,9 +699,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:40,393 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e91255c0>>\n",
-      "CPU times: user 1.34 ms, sys: 1.33 ms, total: 2.68 ms\n",
-      "Wall time: 2.32 ms\n"
+      "2021-07-22 12:05:36,872 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df56c810>>\n",
+      "CPU times: user 1.37 ms, sys: 1.47 ms, total: 2.84 ms\n",
+      "Wall time: 2.84 ms\n"
      ]
     },
     {
@@ -712,25 +738,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:40,430 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table uuid\n",
-      "2020-11-09 14:12:40,433 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table tables\n",
-      "2020-11-09 14:12:40,445 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table samples\n",
-      "2020-11-09 14:12:40,454 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table sample_sets\n",
-      "2020-11-09 14:12:40,464 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table trajectories\n",
-      "2020-11-09 14:12:40,476 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table move_changes\n",
-      "2020-11-09 14:12:40,487 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table steps\n",
-      "2020-11-09 14:12:40,495 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table details\n",
-      "2020-11-09 14:12:40,507 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table storable_functions\n",
-      "2020-11-09 14:12:40,520 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table simulation_objects\n",
-      "2020-11-09 14:12:40,536 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table storage_objects\n",
-      "2020-11-09 14:12:40,576 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 0 objects\n",
-      "2020-11-09 14:12:40,577 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
-      "2020-11-09 14:12:40,580 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
-      "2020-11-09 14:12:40,583 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
-      "2020-11-09 14:12:40,584 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
-      "2020-11-09 14:12:40,586 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
-      "2020-11-09 14:12:40,589 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-11-09 14:12:40,591 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n"
+      "2021-07-22 12:05:36,907 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table uuid\n",
+      "2021-07-22 12:05:36,908 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table tables\n",
+      "2021-07-22 12:05:36,910 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table sfr_result_types\n",
+      "2021-07-22 12:05:36,915 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table tags\n",
+      "2021-07-22 12:05:36,939 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table samples\n",
+      "2021-07-22 12:05:36,954 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table sample_sets\n",
+      "2021-07-22 12:05:36,961 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table trajectories\n",
+      "2021-07-22 12:05:36,969 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table move_changes\n",
+      "2021-07-22 12:05:36,977 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table steps\n",
+      "2021-07-22 12:05:37,013 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table details\n",
+      "2021-07-22 12:05:37,025 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table storable_functions\n",
+      "2021-07-22 12:05:37,061 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table simulation_objects\n",
+      "2021-07-22 12:05:37,073 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table storage_objects\n",
+      "2021-07-22 12:05:37,111 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 0 objects\n",
+      "2021-07-22 12:05:37,112 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
+      "2021-07-22 12:05:37,117 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
+      "2021-07-22 12:05:37,124 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2021-07-22 12:05:37,128 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2021-07-22 12:05:37,132 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2021-07-22 12:05:37,136 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:37,141 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n"
      ]
     }
    ],
@@ -761,11 +789,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:40,649 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e8fcaac8>>\n",
-      "2020-11-09 14:12:40,656 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_storage of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e8fcaac8>>\n",
-      "2020-11-09 14:12:40,659 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._eval of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e8fcaac8>>\n",
-      "CPU times: user 6.43 ms, sys: 3.06 ms, total: 9.5 ms\n",
-      "Wall time: 4.02 s\n"
+      "2021-07-22 12:05:37,188 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df3c0750>>\n",
+      "2021-07-22 12:05:37,190 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_storage of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df3c0750>>\n",
+      "2021-07-22 12:05:37,191 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._eval of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df3c0750>>\n",
+      "CPU times: user 5.2 ms, sys: 2.37 ms, total: 7.57 ms\n",
+      "Wall time: 4.01 s\n"
      ]
     },
     {
@@ -795,9 +823,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:44,683 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e8fcaac8>>\n",
-      "CPU times: user 1.32 ms, sys: 823 µs, total: 2.14 ms\n",
-      "Wall time: 3.65 ms\n"
+      "2021-07-22 12:05:41,211 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df3c0750>>\n",
+      "CPU times: user 1.31 ms, sys: 948 µs, total: 2.26 ms\n",
+      "Wall time: 2.6 ms\n"
      ]
     },
     {
@@ -826,23 +854,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:44,697 - openpathsampling.experimental.simstore.storage - DEBUG - Starting save\n",
-      "2020-11-09 14:12:44,705 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
-      "2020-11-09 14:12:44,706 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
-      "2020-11-09 14:12:44,711 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-11-09 14:12:44,733 - openpathsampling.experimental.simstore.storage - DEBUG - Listing all objects to save\n",
-      "2020-11-09 14:12:44,739 - openpathsampling.experimental.simstore.storage - DEBUG - Checking if objects already exist in database\n",
-      "2020-11-09 14:12:44,741 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 2 UUIDs\n",
-      "2020-11-09 14:12:44,742 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 2 UUIDs\n",
-      "2020-11-09 14:12:44,749 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-11-09 14:12:44,751 - openpathsampling.experimental.simstore.storage - INFO - Saving results from 1 storable functions\n",
-      "2020-11-09 14:12:44,760 - openpathsampling.experimental.simstore.storable_functions - INFO - Result type unknown; unable to create table\n",
-      "2020-11-09 14:12:44,762 - openpathsampling.experimental.simstore.storable_functions - DEBUG - Registering new function: 80100521955429081778427985284781047820\n",
-      "2020-11-09 14:12:44,763 - openpathsampling.experimental.simstore.sql_backend - INFO - Registering storable function: UUID: 80100521955429081778427985284781047820 (float)\n",
-      "2020-11-09 14:12:44,835 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-11-09 14:12:44,842 - openpathsampling.experimental.simstore.storage - DEBUG - Filling 1 tables: ['storable_functions']\n",
-      "2020-11-09 14:12:44,843 - openpathsampling.experimental.simstore.storage - DEBUG - Storing 1 objects to table storable_functions\n",
-      "2020-11-09 14:12:44,859 - openpathsampling.experimental.simstore.storage - DEBUG - Storing complete\n"
+      "2021-07-22 12:05:41,223 - openpathsampling.experimental.simstore.storage - DEBUG - Starting save\n",
+      "2021-07-22 12:05:41,230 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
+      "2021-07-22 12:05:41,231 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
+      "2021-07-22 12:05:41,235 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:41,251 - openpathsampling.experimental.simstore.storage - DEBUG - Listing all objects to save\n",
+      "2021-07-22 12:05:41,256 - openpathsampling.experimental.simstore.storage - DEBUG - Found 2 objects\n",
+      "2021-07-22 12:05:41,258 - openpathsampling.experimental.simstore.storage - DEBUG - Deproxying proxy objects\n",
+      "2021-07-22 12:05:41,261 - openpathsampling.experimental.simstore.storage - DEBUG - Found 0 objects to deproxy\n",
+      "2021-07-22 12:05:41,262 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 0 objects\n",
+      "2021-07-22 12:05:41,263 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
+      "2021-07-22 12:05:41,264 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
+      "2021-07-22 12:05:41,265 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2021-07-22 12:05:41,266 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2021-07-22 12:05:41,267 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2021-07-22 12:05:41,280 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:41,298 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n",
+      "2021-07-22 12:05:41,323 - openpathsampling.experimental.simstore.storage - DEBUG - Checking if objects already exist in database\n",
+      "2021-07-22 12:05:41,324 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 2 UUIDs\n",
+      "2021-07-22 12:05:41,327 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 2 UUIDs\n",
+      "2021-07-22 12:05:41,349 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:41,361 - openpathsampling.experimental.simstore.storage - INFO - Saving results from 1 storable functions\n",
+      "2021-07-22 12:05:41,362 - openpathsampling.experimental.simstore.storable_functions - INFO - Result type unknown; unable to create table\n",
+      "2021-07-22 12:05:41,363 - openpathsampling.experimental.simstore.storable_functions - DEBUG - Registering new function: 218455970078904451893013535049010642956\n",
+      "2021-07-22 12:05:41,364 - openpathsampling.experimental.simstore.storable_functions - DEBUG - Result type: float\n",
+      "2021-07-22 12:05:41,365 - openpathsampling.experimental.simstore.sql_backend - INFO - Registering storable function: UUID: 218455970078904451893013535049010642956 (float)\n",
+      "2021-07-22 12:05:41,396 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:41,401 - openpathsampling.experimental.simstore.storage - DEBUG - Filling 1 tables: ['storable_functions']\n",
+      "2021-07-22 12:05:41,402 - openpathsampling.experimental.simstore.storage - DEBUG - Storing 1 objects to table storable_functions\n",
+      "2021-07-22 12:05:41,416 - openpathsampling.experimental.simstore.storage - DEBUG - Storing complete\n"
      ]
     }
    ],
@@ -859,11 +899,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:44,868 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e8fcaac8>>\n",
-      "2020-11-09 14:12:44,871 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_storage of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e8fcaac8>>\n",
-      "2020-11-09 14:12:44,875 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 2 UUIDs\n",
-      "CPU times: user 5.77 ms, sys: 2.6 ms, total: 8.37 ms\n",
-      "Wall time: 9.75 ms\n"
+      "2021-07-22 12:05:41,424 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df3c0750>>\n",
+      "2021-07-22 12:05:41,426 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_storage of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df3c0750>>\n",
+      "2021-07-22 12:05:41,429 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 2 UUIDs\n",
+      "CPU times: user 4.67 ms, sys: 2.31 ms, total: 6.98 ms\n",
+      "Wall time: 6.56 ms\n"
      ]
     },
     {
@@ -904,47 +944,61 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:44,913 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table uuid\n",
-      "2020-11-09 14:12:44,916 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table tables\n",
-      "2020-11-09 14:12:44,941 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table samples\n",
-      "2020-11-09 14:12:44,962 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table sample_sets\n",
-      "2020-11-09 14:12:44,978 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table trajectories\n",
-      "2020-11-09 14:12:44,989 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table move_changes\n",
-      "2020-11-09 14:12:45,003 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table steps\n",
-      "2020-11-09 14:12:45,012 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table details\n",
-      "2020-11-09 14:12:45,024 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table storable_functions\n",
-      "2020-11-09 14:12:45,038 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table simulation_objects\n",
-      "2020-11-09 14:12:45,058 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table storage_objects\n",
-      "2020-11-09 14:12:45,088 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 0 objects\n",
-      "2020-11-09 14:12:45,089 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
-      "2020-11-09 14:12:45,091 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
-      "2020-11-09 14:12:45,092 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
-      "2020-11-09 14:12:45,096 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
-      "2020-11-09 14:12:45,098 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
-      "2020-11-09 14:12:45,101 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-11-09 14:12:45,105 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n",
-      "2020-11-09 14:12:45,116 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e9125160>>\n",
-      "2020-11-09 14:12:45,120 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_storage of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e9125160>>\n",
-      "2020-11-09 14:12:45,123 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._eval of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e9125160>>\n",
-      "2020-11-09 14:12:47,126 - openpathsampling.experimental.simstore.storage - DEBUG - Starting save\n",
-      "2020-11-09 14:12:47,129 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
-      "2020-11-09 14:12:47,138 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
-      "2020-11-09 14:12:47,143 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-11-09 14:12:47,144 - openpathsampling.experimental.simstore.storage - DEBUG - Listing all objects to save\n",
-      "2020-11-09 14:12:47,146 - openpathsampling.experimental.simstore.storage - DEBUG - Checking if objects already exist in database\n",
-      "2020-11-09 14:12:47,158 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 3 UUIDs\n",
-      "2020-11-09 14:12:47,170 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 3 UUIDs\n",
-      "2020-11-09 14:12:47,186 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-11-09 14:12:47,188 - openpathsampling.experimental.simstore.storage - INFO - Saving results from 1 storable functions\n",
-      "2020-11-09 14:12:47,189 - openpathsampling.experimental.simstore.storable_functions - INFO - Result type unknown; unable to create table\n",
-      "2020-11-09 14:12:47,190 - openpathsampling.experimental.simstore.storable_functions - DEBUG - Registering new function: 80100521955429081778427985284781047852\n",
-      "2020-11-09 14:12:47,191 - openpathsampling.experimental.simstore.sql_backend - INFO - Registering storable function: UUID: 80100521955429081778427985284781047852 (float)\n",
-      "2020-11-09 14:12:47,206 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-11-09 14:12:47,210 - openpathsampling.experimental.simstore.storage - DEBUG - Filling 2 tables: ['simulation_objects', 'storable_functions']\n",
-      "2020-11-09 14:12:47,211 - openpathsampling.experimental.simstore.storage - DEBUG - Storing 1 objects to table simulation_objects\n",
-      "2020-11-09 14:12:47,239 - openpathsampling.experimental.simstore.storage - DEBUG - Storing complete\n",
-      "2020-11-09 14:12:47,240 - openpathsampling.experimental.simstore.storage - DEBUG - Storing 1 objects to table storable_functions\n",
-      "2020-11-09 14:12:47,251 - openpathsampling.experimental.simstore.storage - DEBUG - Storing complete\n"
+      "2021-07-22 12:05:41,451 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table uuid\n",
+      "2021-07-22 12:05:41,453 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table tables\n",
+      "2021-07-22 12:05:41,456 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table sfr_result_types\n",
+      "2021-07-22 12:05:41,458 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table tags\n",
+      "2021-07-22 12:05:41,478 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table samples\n",
+      "2021-07-22 12:05:41,490 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table sample_sets\n",
+      "2021-07-22 12:05:41,512 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table trajectories\n",
+      "2021-07-22 12:05:41,531 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table move_changes\n",
+      "2021-07-22 12:05:41,540 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table steps\n",
+      "2021-07-22 12:05:41,549 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table details\n",
+      "2021-07-22 12:05:41,560 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table storable_functions\n",
+      "2021-07-22 12:05:41,567 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table simulation_objects\n",
+      "2021-07-22 12:05:41,583 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table storage_objects\n",
+      "2021-07-22 12:05:41,674 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 0 objects\n",
+      "2021-07-22 12:05:41,675 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
+      "2021-07-22 12:05:41,677 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
+      "2021-07-22 12:05:41,678 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2021-07-22 12:05:41,680 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2021-07-22 12:05:41,692 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2021-07-22 12:05:41,699 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:41,702 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n",
+      "2021-07-22 12:05:41,720 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df654d10>>\n",
+      "2021-07-22 12:05:41,723 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_storage of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df654d10>>\n",
+      "2021-07-22 12:05:41,726 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._eval of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df654d10>>\n",
+      "2021-07-22 12:05:43,733 - openpathsampling.experimental.simstore.storage - DEBUG - Starting save\n",
+      "2021-07-22 12:05:43,733 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
+      "2021-07-22 12:05:43,734 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
+      "2021-07-22 12:05:43,737 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:43,738 - openpathsampling.experimental.simstore.storage - DEBUG - Listing all objects to save\n",
+      "2021-07-22 12:05:43,739 - openpathsampling.experimental.simstore.storage - DEBUG - Found 3 objects\n",
+      "2021-07-22 12:05:43,741 - openpathsampling.experimental.simstore.storage - DEBUG - Deproxying proxy objects\n",
+      "2021-07-22 12:05:43,742 - openpathsampling.experimental.simstore.storage - DEBUG - Found 0 objects to deproxy\n",
+      "2021-07-22 12:05:43,743 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 0 objects\n",
+      "2021-07-22 12:05:43,744 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
+      "2021-07-22 12:05:43,745 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
+      "2021-07-22 12:05:43,746 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2021-07-22 12:05:43,747 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2021-07-22 12:05:43,747 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2021-07-22 12:05:43,752 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:43,753 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n",
+      "2021-07-22 12:05:43,754 - openpathsampling.experimental.simstore.storage - DEBUG - Checking if objects already exist in database\n",
+      "2021-07-22 12:05:43,755 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 3 UUIDs\n",
+      "2021-07-22 12:05:43,756 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 3 UUIDs\n",
+      "2021-07-22 12:05:43,759 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:43,761 - openpathsampling.experimental.simstore.storage - INFO - Saving results from 1 storable functions\n",
+      "2021-07-22 12:05:43,762 - openpathsampling.experimental.simstore.storable_functions - INFO - Result type unknown; unable to create table\n",
+      "2021-07-22 12:05:43,768 - openpathsampling.experimental.simstore.storable_functions - DEBUG - Registering new function: 218455970078904451893013535049010642988\n",
+      "2021-07-22 12:05:43,783 - openpathsampling.experimental.simstore.storable_functions - DEBUG - Result type: float\n",
+      "2021-07-22 12:05:43,802 - openpathsampling.experimental.simstore.sql_backend - INFO - Registering storable function: UUID: 218455970078904451893013535049010642988 (float)\n",
+      "2021-07-22 12:05:43,838 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:43,848 - openpathsampling.experimental.simstore.storage - DEBUG - Filling 2 tables: ['simulation_objects', 'storable_functions']\n",
+      "2021-07-22 12:05:43,849 - openpathsampling.experimental.simstore.storage - DEBUG - Storing 1 objects to table simulation_objects\n",
+      "2021-07-22 12:05:43,888 - openpathsampling.experimental.simstore.storage - DEBUG - Storing complete\n",
+      "2021-07-22 12:05:43,889 - openpathsampling.experimental.simstore.storage - DEBUG - Storing 1 objects to table storable_functions\n",
+      "2021-07-22 12:05:43,909 - openpathsampling.experimental.simstore.storage - DEBUG - Storing complete\n"
      ]
     }
    ],
@@ -970,10 +1024,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:47,261 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e9125160>>\n",
-      "2020-11-09 14:12:47,262 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_storage of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e9125160>>\n",
-      "2020-11-09 14:12:47,268 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-11-09 14:12:47,269 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._eval of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e9125160>>\n"
+      "2021-07-22 12:05:43,917 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df654d10>>\n",
+      "2021-07-22 12:05:43,919 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_storage of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df654d10>>\n",
+      "2021-07-22 12:05:43,958 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:43,964 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._eval of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df654d10>>\n"
      ]
     },
     {
@@ -1000,7 +1054,7 @@
     {
      "data": {
       "text/plain": [
-       "{'80100521955429081778427985284781047824': 3.0}"
+       "{'218455970078904451893013535049010642960': 3.0}"
       ]
      },
      "execution_count": 39,
@@ -1021,10 +1075,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:49,326 - openpathsampling.experimental.simstore.storage - DEBUG - Starting save\n",
-      "2020-11-09 14:12:49,328 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
-      "2020-11-09 14:12:49,330 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
-      "2020-11-09 14:12:49,350 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 1 UUIDs\n"
+      "2021-07-22 12:05:45,997 - openpathsampling.experimental.simstore.storage - DEBUG - Starting save\n",
+      "2021-07-22 12:05:46,001 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
+      "2021-07-22 12:05:46,002 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
+      "2021-07-22 12:05:46,012 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 1 UUIDs\n"
      ]
     }
    ],
@@ -1040,7 +1094,7 @@
     {
      "data": {
       "text/plain": [
-       "{'80100521955429081778427985284781047824': 3.0}"
+       "{'218455970078904451893013535049010642960': 3.0}"
       ]
      },
      "execution_count": 41,
@@ -1061,7 +1115,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:49,427 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n"
+      "2021-07-22 12:05:46,084 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n"
      ]
     }
    ],
@@ -1077,8 +1131,8 @@
     {
      "data": {
       "text/plain": [
-       "{'80100521955429081778427985284781047824': 3.0,\n",
-       " '80100521955429081778427985284781047858': 2.0}"
+       "{'218455970078904451893013535049010642960': 3.0,\n",
+       " '218455970078904451893013535049010642994': 2.0}"
       ]
      },
      "execution_count": 43,
@@ -1098,8 +1152,8 @@
     {
      "data": {
       "text/plain": [
-       "{'80100521955429081778427985284781047824': 3.0,\n",
-       " '80100521955429081778427985284781047858': 2.0}"
+       "{'218455970078904451893013535049010642960': 3.0,\n",
+       " '218455970078904451893013535049010642994': 2.0}"
       ]
      },
      "execution_count": 44,
@@ -1127,9 +1181,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:49,467 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e91934a8>>\n",
-      "2020-11-09 14:12:49,468 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_storage of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e91934a8>>\n",
-      "2020-11-09 14:12:49,469 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._eval of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e91934a8>>\n"
+      "2021-07-22 12:05:46,178 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df6cc190>>\n",
+      "2021-07-22 12:05:46,179 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_storage of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df6cc190>>\n",
+      "2021-07-22 12:05:46,180 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._eval of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df6cc190>>\n"
      ]
     },
     {
@@ -1176,8 +1230,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e91934a8>\n",
-      "<openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e917c748>\n"
+      "<openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df6cc190>\n",
+      "<openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df6ccc50>\n"
      ]
     }
    ],
@@ -1223,11 +1277,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:51,570 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e917c748>>\n",
-      "2020-11-09 14:12:51,573 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_storage of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e917c748>>\n",
-      "2020-11-09 14:12:51,575 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._eval of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e917c748>>\n",
-      "CPU times: user 4.5 ms, sys: 2.13 ms, total: 6.62 ms\n",
-      "Wall time: 2.01 s\n"
+      "2021-07-22 12:05:48,290 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df6ccc50>>\n",
+      "2021-07-22 12:05:48,295 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_storage of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df6ccc50>>\n",
+      "2021-07-22 12:05:48,300 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._eval of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df6ccc50>>\n",
+      "CPU times: user 5.79 ms, sys: 2.66 ms, total: 8.45 ms\n",
+      "Wall time: 2.02 s\n"
      ]
     },
     {
@@ -1254,7 +1308,7 @@
     {
      "data": {
       "text/plain": [
-       "{'80100521955429081778427985284781047868': 4.0}"
+       "{'218455970078904451893013535049010643004': 4.0}"
       ]
      },
      "execution_count": 51,
@@ -1292,9 +1346,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "<openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e91934a8>\n",
-      "<openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e917c748>\n",
-      "<openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e90ef048>\n"
+      "<openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df6cc190>\n",
+      "<openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df6ccc50>\n",
+      "<openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df6cbd10>\n"
      ]
     }
    ],
@@ -1320,9 +1374,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:53,693 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e90ef048>>\n",
-      "2020-11-09 14:12:53,703 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_storage of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e90ef048>>\n",
-      "2020-11-09 14:12:53,705 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._eval of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7fa4e90ef048>>\n"
+      "2021-07-22 12:05:50,393 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_cached of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df6cbd10>>\n",
+      "2021-07-22 12:05:50,399 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._get_storage of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df6cbd10>>\n",
+      "2021-07-22 12:05:50,404 - openpathsampling.experimental.simstore.storable_functions - DEBUG - <bound method StorableFunction._eval of <openpathsampling.experimental.simstore.storable_functions.StorableFunction object at 0x7f85df6cbd10>>\n"
      ]
     },
     {
@@ -1348,7 +1402,7 @@
     {
      "data": {
       "text/plain": [
-       "{'80100521955429081778427985284781047874': 5.0}"
+       "{'218455970078904451893013535049010643010': 5.0}"
       ]
      },
      "execution_count": 56,
@@ -1380,25 +1434,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:55,745 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table uuid\n",
-      "2020-11-09 14:12:55,746 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table tables\n",
-      "2020-11-09 14:12:55,758 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table samples\n",
-      "2020-11-09 14:12:55,771 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table sample_sets\n",
-      "2020-11-09 14:12:55,779 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table trajectories\n",
-      "2020-11-09 14:12:55,786 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table move_changes\n",
-      "2020-11-09 14:12:55,795 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table steps\n",
-      "2020-11-09 14:12:55,803 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table details\n",
-      "2020-11-09 14:12:55,822 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table storable_functions\n",
-      "2020-11-09 14:12:55,832 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table simulation_objects\n",
-      "2020-11-09 14:12:55,845 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table storage_objects\n",
-      "2020-11-09 14:12:55,951 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 0 objects\n",
-      "2020-11-09 14:12:55,953 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
-      "2020-11-09 14:12:55,953 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
-      "2020-11-09 14:12:55,955 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
-      "2020-11-09 14:12:55,962 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
-      "2020-11-09 14:12:55,969 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
-      "2020-11-09 14:12:55,994 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-11-09 14:12:55,995 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n"
+      "2021-07-22 12:05:52,447 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table uuid\n",
+      "2021-07-22 12:05:52,456 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table tables\n",
+      "2021-07-22 12:05:52,463 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table sfr_result_types\n",
+      "2021-07-22 12:05:52,470 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table tags\n",
+      "2021-07-22 12:05:52,497 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table samples\n",
+      "2021-07-22 12:05:52,518 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table sample_sets\n",
+      "2021-07-22 12:05:52,535 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table trajectories\n",
+      "2021-07-22 12:05:52,558 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table move_changes\n",
+      "2021-07-22 12:05:52,590 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table steps\n",
+      "2021-07-22 12:05:52,610 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table details\n",
+      "2021-07-22 12:05:52,635 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table storable_functions\n",
+      "2021-07-22 12:05:52,651 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table simulation_objects\n",
+      "2021-07-22 12:05:52,669 - openpathsampling.experimental.simstore.sql_backend - INFO - Add schema table storage_objects\n",
+      "2021-07-22 12:05:52,735 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 0 objects\n",
+      "2021-07-22 12:05:52,737 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
+      "2021-07-22 12:05:52,738 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
+      "2021-07-22 12:05:52,740 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2021-07-22 12:05:52,742 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2021-07-22 12:05:52,744 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2021-07-22 12:05:52,748 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:52,753 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n"
      ]
     }
    ],
@@ -1420,23 +1476,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:56,024 - openpathsampling.experimental.simstore.storage - DEBUG - Starting save\n",
-      "2020-11-09 14:12:56,025 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
-      "2020-11-09 14:12:56,026 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
-      "2020-11-09 14:12:56,030 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-11-09 14:12:56,031 - openpathsampling.experimental.simstore.storage - DEBUG - Listing all objects to save\n",
-      "2020-11-09 14:12:56,032 - openpathsampling.experimental.simstore.storage - DEBUG - Checking if objects already exist in database\n",
-      "2020-11-09 14:12:56,032 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 2 UUIDs\n",
-      "2020-11-09 14:12:56,034 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 2 UUIDs\n",
-      "2020-11-09 14:12:56,054 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-11-09 14:12:56,056 - openpathsampling.experimental.simstore.storage - INFO - Saving results from 1 storable functions\n",
-      "2020-11-09 14:12:56,058 - openpathsampling.experimental.simstore.storable_functions - INFO - Result type unknown; unable to create table\n",
-      "2020-11-09 14:12:56,060 - openpathsampling.experimental.simstore.storable_functions - DEBUG - Registering new function: 80100521955429081778427985284781047860\n",
-      "2020-11-09 14:12:56,062 - openpathsampling.experimental.simstore.sql_backend - INFO - Registering storable function: UUID: 80100521955429081778427985284781047860 (float)\n",
-      "2020-11-09 14:12:56,098 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-11-09 14:12:56,106 - openpathsampling.experimental.simstore.storage - DEBUG - Filling 1 tables: ['storable_functions']\n",
-      "2020-11-09 14:12:56,107 - openpathsampling.experimental.simstore.storage - DEBUG - Storing 1 objects to table storable_functions\n",
-      "2020-11-09 14:12:56,120 - openpathsampling.experimental.simstore.storage - DEBUG - Storing complete\n"
+      "2021-07-22 12:05:52,797 - openpathsampling.experimental.simstore.storage - DEBUG - Starting save\n",
+      "2021-07-22 12:05:52,801 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
+      "2021-07-22 12:05:52,821 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
+      "2021-07-22 12:05:52,830 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:52,833 - openpathsampling.experimental.simstore.storage - DEBUG - Listing all objects to save\n",
+      "2021-07-22 12:05:52,835 - openpathsampling.experimental.simstore.storage - DEBUG - Found 2 objects\n",
+      "2021-07-22 12:05:52,837 - openpathsampling.experimental.simstore.storage - DEBUG - Deproxying proxy objects\n",
+      "2021-07-22 12:05:52,839 - openpathsampling.experimental.simstore.storage - DEBUG - Found 0 objects to deproxy\n",
+      "2021-07-22 12:05:52,841 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 0 objects\n",
+      "2021-07-22 12:05:52,844 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
+      "2021-07-22 12:05:52,846 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
+      "2021-07-22 12:05:52,847 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2021-07-22 12:05:52,849 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2021-07-22 12:05:52,851 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2021-07-22 12:05:52,857 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:52,859 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n",
+      "2021-07-22 12:05:52,861 - openpathsampling.experimental.simstore.storage - DEBUG - Checking if objects already exist in database\n",
+      "2021-07-22 12:05:52,865 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 2 UUIDs\n",
+      "2021-07-22 12:05:52,867 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 2 UUIDs\n",
+      "2021-07-22 12:05:52,876 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:52,877 - openpathsampling.experimental.simstore.storage - INFO - Saving results from 1 storable functions\n",
+      "2021-07-22 12:05:52,880 - openpathsampling.experimental.simstore.storable_functions - INFO - Result type unknown; unable to create table\n",
+      "2021-07-22 12:05:52,883 - openpathsampling.experimental.simstore.storable_functions - DEBUG - Registering new function: 218455970078904451893013535049010642996\n",
+      "2021-07-22 12:05:52,885 - openpathsampling.experimental.simstore.storable_functions - DEBUG - Result type: float\n",
+      "2021-07-22 12:05:52,886 - openpathsampling.experimental.simstore.sql_backend - INFO - Registering storable function: UUID: 218455970078904451893013535049010642996 (float)\n",
+      "2021-07-22 12:05:52,908 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:52,925 - openpathsampling.experimental.simstore.storage - DEBUG - Filling 1 tables: ['storable_functions']\n",
+      "2021-07-22 12:05:52,927 - openpathsampling.experimental.simstore.storage - DEBUG - Storing 1 objects to table storable_functions\n",
+      "2021-07-22 12:05:52,945 - openpathsampling.experimental.simstore.storage - DEBUG - Storing complete\n"
      ]
     }
    ],
@@ -1453,18 +1521,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:56,133 - openpathsampling.experimental.simstore.storage - DEBUG - Starting save\n",
-      "2020-11-09 14:12:56,134 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
-      "2020-11-09 14:12:56,135 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
-      "2020-11-09 14:12:56,141 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 1 UUIDs\n",
-      "2020-11-09 14:12:56,143 - openpathsampling.experimental.simstore.storage - DEBUG - Listing all objects to save\n",
-      "2020-11-09 14:12:56,144 - openpathsampling.experimental.simstore.storage - DEBUG - Checking if objects already exist in database\n",
-      "2020-11-09 14:12:56,147 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
-      "2020-11-09 14:12:56,150 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
-      "2020-11-09 14:12:56,160 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-11-09 14:12:56,161 - openpathsampling.experimental.simstore.storage - INFO - Saving results from 1 storable functions\n",
-      "2020-11-09 14:12:56,166 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-11-09 14:12:56,176 - openpathsampling.experimental.simstore.storage - DEBUG - Filling 0 tables: []\n"
+      "2021-07-22 12:05:52,960 - openpathsampling.experimental.simstore.storage - DEBUG - Starting save\n",
+      "2021-07-22 12:05:52,963 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
+      "2021-07-22 12:05:52,964 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
+      "2021-07-22 12:05:52,972 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 1 UUIDs\n",
+      "2021-07-22 12:05:52,974 - openpathsampling.experimental.simstore.storage - DEBUG - Listing all objects to save\n",
+      "2021-07-22 12:05:52,975 - openpathsampling.experimental.simstore.storage - DEBUG - Found 1 objects\n",
+      "2021-07-22 12:05:52,978 - openpathsampling.experimental.simstore.storage - DEBUG - Deproxying proxy objects\n",
+      "2021-07-22 12:05:52,979 - openpathsampling.experimental.simstore.storage - DEBUG - Found 0 objects to deproxy\n",
+      "2021-07-22 12:05:52,981 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 0 objects\n",
+      "2021-07-22 12:05:52,982 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
+      "2021-07-22 12:05:52,984 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
+      "2021-07-22 12:05:52,985 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2021-07-22 12:05:52,988 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2021-07-22 12:05:52,989 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2021-07-22 12:05:52,993 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:52,994 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n",
+      "2021-07-22 12:05:52,996 - openpathsampling.experimental.simstore.storage - DEBUG - Checking if objects already exist in database\n",
+      "2021-07-22 12:05:53,005 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
+      "2021-07-22 12:05:53,007 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
+      "2021-07-22 12:05:53,018 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:53,023 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:53,025 - openpathsampling.experimental.simstore.storage - INFO - Saving results from 1 storable functions\n",
+      "2021-07-22 12:05:53,030 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:53,045 - openpathsampling.experimental.simstore.storage - DEBUG - Filling 0 tables: []\n"
      ]
     }
    ],
@@ -1481,18 +1561,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2020-11-09 14:12:56,193 - openpathsampling.experimental.simstore.storage - DEBUG - Starting save\n",
-      "2020-11-09 14:12:56,197 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
-      "2020-11-09 14:12:56,199 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
-      "2020-11-09 14:12:56,204 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 1 UUIDs\n",
-      "2020-11-09 14:12:56,206 - openpathsampling.experimental.simstore.storage - DEBUG - Listing all objects to save\n",
-      "2020-11-09 14:12:56,208 - openpathsampling.experimental.simstore.storage - DEBUG - Checking if objects already exist in database\n",
-      "2020-11-09 14:12:56,210 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
-      "2020-11-09 14:12:56,211 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
-      "2020-11-09 14:12:56,215 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-11-09 14:12:56,217 - openpathsampling.experimental.simstore.storage - INFO - Saving results from 1 storable functions\n",
-      "2020-11-09 14:12:56,221 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
-      "2020-11-09 14:12:56,227 - openpathsampling.experimental.simstore.storage - DEBUG - Filling 0 tables: []\n"
+      "2021-07-22 12:05:53,060 - openpathsampling.experimental.simstore.storage - DEBUG - Starting save\n",
+      "2021-07-22 12:05:53,063 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
+      "2021-07-22 12:05:53,065 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
+      "2021-07-22 12:05:53,069 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 1 UUIDs\n",
+      "2021-07-22 12:05:53,070 - openpathsampling.experimental.simstore.storage - DEBUG - Listing all objects to save\n",
+      "2021-07-22 12:05:53,071 - openpathsampling.experimental.simstore.storage - DEBUG - Found 1 objects\n",
+      "2021-07-22 12:05:53,072 - openpathsampling.experimental.simstore.storage - DEBUG - Deproxying proxy objects\n",
+      "2021-07-22 12:05:53,074 - openpathsampling.experimental.simstore.storage - DEBUG - Found 0 objects to deproxy\n",
+      "2021-07-22 12:05:53,077 - openpathsampling.experimental.simstore.storage - DEBUG - Starting to load 0 objects\n",
+      "2021-07-22 12:05:53,078 - openpathsampling.experimental.simstore.storage - DEBUG - Getting internal structure of 0 non-cached objects\n",
+      "2021-07-22 12:05:53,080 - openpathsampling.experimental.simstore.storage - DEBUG - Loading 0 objects; creating 0 lazy proxies\n",
+      "2021-07-22 12:05:53,082 - openpathsampling.experimental.simstore.storage - DEBUG - Identifying classes for 0 lazy proxies\n",
+      "2021-07-22 12:05:53,085 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 0 UUIDs\n",
+      "2021-07-22 12:05:53,088 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 0 UUIDs\n",
+      "2021-07-22 12:05:53,093 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:53,094 - openpathsampling.experimental.simstore.storage - DEBUG - Reconstructing from 0 objects\n",
+      "2021-07-22 12:05:53,096 - openpathsampling.experimental.simstore.storage - DEBUG - Checking if objects already exist in database\n",
+      "2021-07-22 12:05:53,098 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Looking for 1 UUIDs\n",
+      "2021-07-22 12:05:53,100 - openpathsampling.experimental.simstore.sql_backend - DEBUG - New block of 1 UUIDs\n",
+      "2021-07-22 12:05:53,107 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:53,113 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:53,115 - openpathsampling.experimental.simstore.storage - INFO - Saving results from 1 storable functions\n",
+      "2021-07-22 12:05:53,119 - openpathsampling.experimental.simstore.sql_backend - DEBUG - Found 0 UUIDs\n",
+      "2021-07-22 12:05:53,126 - openpathsampling.experimental.simstore.storage - DEBUG - Filling 0 tables: []\n"
      ]
     }
    ],
@@ -1508,7 +1600,7 @@
     {
      "data": {
       "text/plain": [
-       "<openpathsampling.experimental.simstore.storable_functions.StorableFunction at 0x7fa4e90ef048>"
+       "<openpathsampling.experimental.simstore.storable_functions.StorableFunction at 0x7f85df6cbd10>"
       ]
      },
      "execution_count": 61,
@@ -1528,9 +1620,9 @@
     {
      "data": {
       "text/plain": [
-       "{'80100521955429081778427985284781047824': 3.0,\n",
-       " '80100521955429081778427985284781047868': 4.0,\n",
-       " '80100521955429081778427985284781047874': 5.0}"
+       "{'218455970078904451893013535049010642960': 3.0,\n",
+       " '218455970078904451893013535049010643004': 4.0,\n",
+       " '218455970078904451893013535049010643010': 5.0}"
       ]
      },
      "execution_count": 62,
@@ -1550,7 +1642,7 @@
     {
      "data": {
       "text/plain": [
-       "{'80100521955429081778427985284781047860': <openpathsampling.experimental.simstore.storable_functions.StorableFunction at 0x7fa4e91934a8>}"
+       "{'218455970078904451893013535049010642996': <openpathsampling.experimental.simstore.storable_functions.StorableFunction at 0x7f85df6cc190>}"
       ]
      },
      "execution_count": 63,
@@ -1571,10 +1663,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "80100521955429081778427985284781047860\n",
-      "80100521955429081778427985284781047820\n",
-      "80100521955429081778427985284781047860\n",
-      "80100521955429081778427985284781047860\n"
+      "218455970078904451893013535049010642996\n",
+      "218455970078904451893013535049010642956\n",
+      "218455970078904451893013535049010642996\n",
+      "218455970078904451893013535049010642996\n"
      ]
     }
    ],
@@ -1608,9 +1700,9 @@
     {
      "data": {
       "text/plain": [
-       "{'80100521955429081778427985284781047824': 3.0,\n",
-       " '80100521955429081778427985284781047868': 4.0,\n",
-       " '80100521955429081778427985284781047874': 5.0}"
+       "{'218455970078904451893013535049010642960': 3.0,\n",
+       " '218455970078904451893013535049010643004': 4.0,\n",
+       " '218455970078904451893013535049010643010': 5.0}"
       ]
      },
      "execution_count": 67,
@@ -1631,9 +1723,9 @@
      "data": {
       "text/plain": [
        "defaultdict(list,\n",
-       "            {'80100521955429081778427985284781047860': [<openpathsampling.experimental.simstore.storable_functions.StorableFunction at 0x7fa4e91934a8>,\n",
-       "              <openpathsampling.experimental.simstore.storable_functions.StorableFunction at 0x7fa4e917c748>,\n",
-       "              <openpathsampling.experimental.simstore.storable_functions.StorableFunction at 0x7fa4e90ef048>]})"
+       "            {'218455970078904451893013535049010642996': [<openpathsampling.experimental.simstore.storable_functions.StorableFunction at 0x7f85df6cc190>,\n",
+       "              <openpathsampling.experimental.simstore.storable_functions.StorableFunction at 0x7f85df6ccc50>,\n",
+       "              <openpathsampling.experimental.simstore.storable_functions.StorableFunction at 0x7f85df6cbd10>]})"
       ]
      },
      "execution_count": 68,
@@ -1675,7 +1767,7 @@
      "data": {
       "text/plain": [
        "defaultdict(list,\n",
-       "            {'80100521955429081778427985284781047860': [<openpathsampling.experimental.simstore.storable_functions.StorableFunction at 0x7fa4e91934a8>]})"
+       "            {'218455970078904451893013535049010642996': [<openpathsampling.experimental.simstore.storable_functions.StorableFunction at 0x7f85df6cc190>]})"
       ]
      },
      "execution_count": 71,
@@ -1721,7 +1813,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.10"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Fixes issues from behind-the-scenes changes introduced by https://github.com/openpathsampling/openpathsampling/pull/1035.

This issue makes me think that the current approach for registering serialization types isn't the most natural, but fixes on that can come another time.