### PR TITLE
Fix testing errors with coverage 6.1.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,9 +35,13 @@ jobs:
           pushd ..
           CONDA_PY="3.7" source ${DIR}/conda_ops_dev_install.sh
           popd
+      - name: "Fixes"
+        run: |
           # for some reason, conda is currently pulling in (old) networkx 2.3 and
           # matplotlib 3.4.1 (which is new, but not compatible)
           conda update -y -c conda-forge networkx
+          # it looks like we're getting errors on old pyparsing (before 3.0)
+          conda update -y -c conda-forge pyparsing>=3.0.4
       - name: "Versions"
         run: conda list
       - name: "Tests"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
           conda update -y -c conda-forge networkx
           # it looks like we're getting errors on old pyparsing (before 3.0)
           conda update -y -c conda-forge pyparsing>=3.0.4
-          conda update -y -c conda-forge coverage<=6.0
+          conda update -y -c conda-forge "coverage<6.0"
       - name: "Versions"
         run: conda list
       - name: "Tests"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,7 @@ jobs:
           conda update -y -c conda-forge networkx
           # it looks like we're getting errors on old pyparsing (before 3.0)
           conda update -y -c conda-forge pyparsing>=3.0.4
+          conda update -y -c conda-forge coverage<=6.0
       - name: "Versions"
         run: conda list
       - name: "Tests"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,8 +40,7 @@ jobs:
           # for some reason, conda is currently pulling in (old) networkx 2.3 and
           # matplotlib 3.4.1 (which is new, but not compatible)
           conda update -y -c conda-forge networkx
-          # it looks like we're getting errors on old pyparsing (before 3.0)
-          conda update -y -c conda-forge pyparsing>=3.0.4
+          # it looks like we're getting errors on new coverage
           conda install -y -c conda-forge "coverage<6.0"
       - name: "Versions"
         run: conda list

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
           conda update -y -c conda-forge networkx
           # it looks like we're getting errors on old pyparsing (before 3.0)
           conda update -y -c conda-forge pyparsing>=3.0.4
-          conda update -y -c conda-forge "coverage<6.0"
+          conda install -y -c conda-forge "coverage<6.0"
       - name: "Versions"
         run: conda list
       - name: "Tests"


### PR DESCRIPTION
Tests have been failing for the last couple of days. The most suspicious changes are `pyparsing 3.0.4 => 2.4.6` and `coverage 5.5 => 6.1.1`, and since the error is coming out of MDTraj, I'm starting with `pyparsing` as the suspect.

<details>
<summary>Full diff comparing "Versions" section of CI</summary>

```diff
8c8
< argon2-cffi               21.1.0           py37h5e8e339_1    conda-forge
---
> argon2-cffi               21.1.0           py37h5e8e339_2    conda-forge
18c18
< brotlipy                  0.7.0           py37h5e8e339_1002    conda-forge
---
> brotlipy                  0.7.0           py37h5e8e339_1003    conda-forge
25c25
< cffi                      1.14.6           py37h036bc23_2    conda-forge
---
> cffi                      1.15.0           py37h036bc23_0    conda-forge
31,33c31,33
< coverage                  5.5              py37h27cfd23_2  
< coveralls                 3.2.0              pyhd8ed1ab_0    conda-forge
< cryptography              35.0.0           py37hf1a17b8_1    conda-forge
---
> coverage                  6.1.1            py37h5e8e339_1    conda-forge
> coveralls                 3.3.0              pyhd8ed1ab_0    conda-forge
> cryptography              35.0.0           py37hf1a17b8_2    conda-forge
38c38
< debugpy                   1.4.1            py37hcd2ae1e_1    conda-forge
---
> debugpy                   1.5.1            py37hcd2ae1e_0    conda-forge
111c111
< libpq                     13.3                 hd57d9b9_2    conda-forge
---
> libpq                     13.3                 hd57d9b9_3    conda-forge
163c163
< packaging                 21.0               pyhd8ed1ab_0    conda-forge
---
> packaging                 21.2               pyhd8ed1ab_1    conda-forge
180,181c180,181
< prompt-toolkit            3.0.21             pyha770c72_0    conda-forge
< prompt_toolkit            3.0.21               hd8ed1ab_0    conda-forge
---
> prompt-toolkit            3.0.22             pyha770c72_0    conda-forge
> prompt_toolkit            3.0.22               hd8ed1ab_0    conda-forge
193c193
< pyparsing                 3.0.4              pyhd8ed1ab_0    conda-forge
---
> pyparsing                 2.4.7              pyhd8ed1ab_1    conda-forge
199c199
< pyrsistent                0.17.3           py37h5e8e339_3    conda-forge
---
> pyrsistent                0.18.0           py37h5e8e339_0    conda-forge
218c218
< setuptools                58.4.0           py37h89c1867_1    conda-forge
---
> setuptools                58.5.2           py37h89c1867_0    conda-forge
224c224
< terminado                 0.12.1           py37h89c1867_0    conda-forge
---
> terminado                 0.12.1           py37h89c1867_1    conda-forge
228a229
> tomli                     1.2.2              pyhd8ed1ab_0    conda-forge

```

</details>